### PR TITLE
Fix link error with gcc4.6

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -8,4 +8,4 @@ GOFILES=benchmark.go
 include $(GOROOT)/src/Make.pkg
 
 cstatfs: statfs.cc
-	g++ -O2 -Wall -std=c++0x `pkg-config fuse --cflags --libs` $< -o $@
+	g++ -O2 -Wall -std=c++0x $< `pkg-config fuse --cflags --libs` -o $@


### PR DESCRIPTION
'make cstatfs' resulting below link error.
  statfs.o: In function `main':
  statfs.cc:(.text.startup+0x168): undefined reference to`fuse_main_real'
  collect2: ld returned 1 exit status

(g++ 4.6.1 Ubuntu Oneiric)

Linker flag '--as-needed' is used by default on Ubuntu Oneiric. This
patch fixes the link error by change objects and libraries order.

Signed-off-by: Haitao Li lihaitao@gmail.com
