### PR TITLE
Fix files_linux.go to work on 386

### DIFF
--- a/fuse/files_linux.go
+++ b/fuse/files_linux.go
@@ -24,16 +24,14 @@ func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) Status {
 		tv[0].Usec = _UTIME_OMIT
 	} else {
 		n := a.UnixNano()
-		tv[0].Sec = n / 1e9
-		tv[0].Usec = (n % 1e9) / 1e3
+		tv[0] = syscall.NsecToTimeval(n)
  	}
 
 	if m == nil {
 		tv[1].Usec = _UTIME_OMIT
 	} else {
 		n := a.UnixNano()
-		tv[1].Sec = n / 1e9
-		tv[1].Usec = (n % 1e9) / 1e3
+		tv[1] = syscall.NsecToTimeval(n)
  	}
 	
 	err := syscall.Futimes(int(f.File.Fd()), tv)


### PR DESCRIPTION
Because Timeval has an int32 field on 386, use syscall.NsecToTimeval to build the Timeval in a cross-arch way.
