### PR TITLE
Check for out-of-range condition in dataFile.Read

### DIFF
--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -40,6 +40,10 @@ func NewDataFile(data []byte) File {
 }
 
 func (f *dataFile) Read(buf []byte, off int64) (res fuse.ReadResult, code fuse.Status) {
+	if off >= len(f.data) {
+		return nil, fuse.EINVAL
+	}
+
 	end := int(off) + int(len(buf))
 	if end > len(f.data) {
 		end = len(f.data)


### PR DESCRIPTION
We've been using this library but have noticed the following panic now and then:

```
goroutine 891512 [running]:
github.com/hanwen/go-fuse/fuse/nodefs.(*dataFile).Read(0xc2172927b0, 0xc2000d6000, 0x1000, 0x1000, 0x47f000, ...)
    /gopath/github.com/hanwen/go-fuse/fuse/nodefs/files.go:48 +0x131
github.com/hanwen/go-fuse/fuse/nodefs.(*rawBridge).Read(0xc2000f3440, 0xc2000d5848, 0xc2000d6000, 0x1000, 0x1000, ...)
    /gopath/github.com/hanwen/go-fuse/fuse/nodefs/fsops.go:420 +0x9b
github.com/hanwen/go-fuse/fuse.doRead(0xc2000f41e0, 0xc2000d56c0)
    /gopath/github.com/hanwen/go-fuse/fuse/opcode.go:284 +0x90
github.com/hanwen/go-fuse/fuse.(*Server).handleRequest(0xc2000f41e0, 0xc2000d56c0)
    /gopath/github.com/hanwen/go-fuse/fuse/server.go:334 +0x253
github.com/hanwen/go-fuse/fuse.(*Server).loop(0xc2000f41e0, 0x1)
    /gopath/github.com/hanwen/go-fuse/fuse/server.go:314 +0x86
created by github.com/hanwen/go-fuse/fuse.(*Server).readRequest
    /gopath/github.com/hanwen/go-fuse/fuse/server.go:244 +0x5d2
```

It happens seemingly at random. We're not sure if it happens due to incorrect input on our part, but the stacktrace doesn't tell us much. In any event, I figure the method should probably be checking where it's reading anyway. Let me know what you think, or if you maybe know the root cause of this.
