### PR TITLE
add files_darwin.go

### DIFF
--- a/fuse/nodefs/files_darwin.go
+++ b/fuse/nodefs/files_darwin.go
@@ -1,0 +1,86 @@
+package nodefs
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/hanwen/go-fuse/fuse"
+)
+
+func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {
+	// TODO: Handle `mode` parameter.
+
+	f.lock.Lock()
+
+	// From `man fcntl` on OSX:
+	//     The F_PREALLOCATE command operates on the following structure:
+	//
+	//             typedef struct fstore {
+	//                 u_int32_t fst_flags;      /* IN: flags word */
+	//                 int       fst_posmode;    /* IN: indicates offset field */
+	//                 off_t     fst_offset;     /* IN: start of the region */
+	//                 off_t     fst_length;     /* IN: size of the region */
+	//                 off_t     fst_bytesalloc; /* OUT: number of bytes allocated */
+	//             } fstore_t;
+	//
+	//     The flags (fst_flags) for the F_PREALLOCATE command are as follows:
+	//
+	//           F_ALLOCATECONTIG   Allocate contiguous space.
+	//
+	//           F_ALLOCATEALL      Allocate all requested space or no space at all.
+	//
+	//     The position modes (fst_posmode) for the F_PREALLOCATE command indicate how to use the offset field.  The modes are as fol-
+	//     lows:
+	//
+	//           F_PEOFPOSMODE   Allocate from the physical end of file.
+	//
+	//           F_VOLPOSMODE    Allocate from the volume offset.
+
+	k := struct {
+		Flags      uint32 // u_int32_t
+		Posmode    int64  // int
+		Offset     int64  // off_t
+		Length     int64  // off_t
+		Bytesalloc int64  // off_t
+	}{
+		0,
+		0,
+		int64(off),
+		int64(sz),
+		0,
+	}
+
+	// Linux version for reference:
+	// err := syscall.Fallocate(int(f.File.Fd()), mode, int64(off), int64(sz))
+
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.File.Fd(), uintptr(syscall.F_PREALLOCATE), uintptr(unsafe.Pointer(&k)))
+	f.lock.Unlock()
+	if errno != 0 {
+		return fuse.ToStatus(errno)
+	}
+	return fuse.OK
+}
+
+const _UTIME_NOW = ((1 << 30) - 1)
+const _UTIME_OMIT = ((1 << 30) - 2)
+
+func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
+	tv := make([]syscall.Timeval, 2)
+	if a == nil {
+		tv[0].Usec = _UTIME_OMIT
+	} else {
+		n := a.UnixNano()
+		tv[0] = syscall.NsecToTimeval(n)
+	}
+
+	if m == nil {
+		tv[1].Usec = _UTIME_OMIT
+	} else {
+		n := a.UnixNano()
+		tv[1] = syscall.NsecToTimeval(n)
+	}
+
+	err := syscall.Futimes(int(f.File.Fd()), tv)
+	return fuse.ToStatus(err)
+}


### PR DESCRIPTION
Allows compiling and running on OSX.
- `hello` example not working: `mount_osxfusefs: failed to mount /Users/tzn/m@/dev/osxfuse0: Function not implemented;
- `unionfs` example mostly working
- `loopback` example mostly working

Most examples hang when terminated with ^C, will start consuming 100% CPU and will have to be killed.

ref. issue #16
