### PR TITLE
Fixes CreateIn message size on Darwin

### DIFF
--- a/fuse/print.go
+++ b/fuse/print.go
@@ -101,10 +101,6 @@ func (me *MkdirIn) string() string {
 	return fmt.Sprintf("{0%o (0%o)}", me.Mode, me.Umask)
 }
 
-func (me *MknodIn) string() string {
-	return fmt.Sprintf("{0%o (0%o), %d}", me.Mode, me.Umask, me.Rdev)
-}
-
 func (me *RenameIn) string() string {
 	return fmt.Sprintf("{%d}", me.Newdir)
 }
@@ -178,12 +174,6 @@ func (me *GetXAttrOut) string() string {
 }
 func (me *AccessIn) string() string {
 	return fmt.Sprintf("{%s}", FlagString(accessFlagName, int64(me.Mask), ""))
-}
-
-func (me *CreateIn) string() string {
-	return fmt.Sprintf(
-		"{0%o [%s] (0%o)}", me.Mode,
-		FlagString(OpenFlagNames, int64(me.Flags), "O_RDONLY"), me.Umask)
 }
 
 func (me *FlushIn) string() string {

--- a/fuse/print_darwin.go
+++ b/fuse/print_darwin.go
@@ -25,7 +25,17 @@ func (a *Attr) string() string {
 		a.Ctime, a.Ctimensec)
 }
 
+func (me *CreateIn) string() string {
+	return fmt.Sprintf(
+		"{0%o [%s]}", me.Mode,
+		FlagString(OpenFlagNames, int64(me.Flags), "O_RDONLY"))
+}
+
 func (me *GetAttrIn) string() string { return "" }
+
+func (me *MknodIn) string() string {
+	return fmt.Sprintf("{0%o, %d}", me.Mode, me.Rdev)
+}
 
 func (me *ReadIn) string() string {
 	return fmt.Sprintf("{Fh %d off %d sz %d %s L %d %s}",

--- a/fuse/print_linux.go
+++ b/fuse/print_linux.go
@@ -27,8 +27,18 @@ func (a *Attr) string() string {
 		a.Ctime, a.Ctimensec)
 }
 
+func (me *CreateIn) string() string {
+	return fmt.Sprintf(
+		"{0%o [%s] (0%o)}", me.Mode,
+		FlagString(OpenFlagNames, int64(me.Flags), "O_RDONLY"), me.Umask)
+}
+
 func (me *GetAttrIn) string() string {
 	return fmt.Sprintf("{Fh %d}", me.Fh_)
+}
+
+func (me *MknodIn) string() string {
+	return fmt.Sprintf("{0%o (0%o), %d}", me.Mode, me.Umask, me.Rdev)
 }
 
 func (me *ReadIn) string() string {

--- a/fuse/types.go
+++ b/fuse/types.go
@@ -66,14 +66,6 @@ type LinkIn struct {
 	Oldnodeid uint64
 }
 
-type MknodIn struct {
-	InHeader
-	Mode    uint32
-	Rdev    uint32
-	Umask   uint32
-	Padding uint32
-}
-
 type Owner struct {
 	Uid uint32
 	Gid uint32
@@ -124,8 +116,8 @@ type ReleaseIn struct {
 
 type OpenIn struct {
 	InHeader
-	Flags  uint32
-	Unused uint32
+	Flags uint32
+	Mode  uint32
 }
 
 const (
@@ -260,18 +252,6 @@ type WriteOut struct {
 	Padding uint32
 }
 
-type SetXAttrIn struct {
-	InHeader
-	Size  uint32
-	Flags uint32
-}
-
-type GetXAttrIn struct {
-	InHeader
-	Size    uint32
-	Padding uint32
-}
-
 type GetXAttrOut struct {
 	Size    uint32
 	Padding uint32
@@ -322,14 +302,6 @@ type OutHeader struct {
 	Length uint32
 	Status int32
 	Unique uint64
-}
-
-type CreateIn struct {
-	InHeader
-	Flags   uint32
-	Mode    uint32
-	Umask   uint32
-	Padding uint32
 }
 
 type NotifyInvalInodeOut struct {

--- a/fuse/types_darwin.go
+++ b/fuse/types_darwin.go
@@ -62,6 +62,21 @@ func (g *GetAttrIn) Fh() uint64 {
 	return 0
 }
 
+// Uses OpenIn struct for create.
+type CreateIn struct {
+	InHeader
+
+	Flags uint32
+	Mode  uint32
+}
+
+type MknodIn struct {
+	InHeader
+
+	Mode uint32
+	Rdev uint32
+}
+
 type ReadIn struct {
 	InHeader
 
@@ -77,6 +92,22 @@ type WriteIn struct {
 	Offset     uint64
 	Size       uint32
 	WriteFlags uint32
+}
+
+type SetXAttrIn struct {
+	InHeader
+	Size     uint32
+	Flags    uint32
+	Position uint32
+	Padding  uint32
+}
+
+type GetXAttrIn struct {
+	InHeader
+	Size     uint32
+	Padding  uint32
+	Position uint32
+	Padding2 uint32
 }
 
 const (

--- a/fuse/types_linux.go
+++ b/fuse/types_linux.go
@@ -47,6 +47,22 @@ func (g *GetAttrIn) Fh() uint64 {
 	return g.Fh_
 }
 
+type CreateIn struct {
+	InHeader
+	Flags  uint32
+	Mode   uint32
+	Umask  uint32
+	Pading uint32
+}
+
+type MknodIn struct {
+	InHeader
+	Mode    uint32
+	Rdev    uint32
+	Umask   uint32
+	Padding uint32
+}
+
 type ReadIn struct {
 	InHeader
 	Fh        uint64
@@ -67,4 +83,16 @@ type WriteIn struct {
 	LockOwner  uint64
 	Flags      uint32
 	Padding    uint32
+}
+
+type SetXAttrIn struct {
+	InHeader
+	Size  uint32
+	Flags uint32
+}
+
+type GetXAttrIn struct {
+	InHeader
+	Size    uint32
+	Padding uint32
 }


### PR DESCRIPTION
CreateIn, MknodIn, SetXAttrIn, and GetXAttrIn are separated into Linux and
Darwin-specific versions.

Tested on OSX 10.9.3 with OSXFuse 2.6.4 and Go 1.2.1.

OpenIn is updated to match Linux and OSXFuse definitions - changing the Unused
field to Mode.
