### PR TITLE
Defer Unlock() in handle.go

### DIFF
--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -309,7 +309,7 @@ func (m *int64HandleMap) handle(obj *handled) (handle uint64) {
 
 func (m *int64HandleMap) Handle(obj *handled) (handle uint64) {
 	m.mutex.Lock()
-	m.mutex.Unlock()
+	defer m.mutex.Unlock()
 	return m.handle(obj)
 }
 


### PR DESCRIPTION
Do we have a testing strategy that involves the Go Thread Sanitizer?
https://code.google.com/p/thread-sanitizer/wiki/GoManual