### PR TITLE
Make BufferPool.AllocBuffer() return a buffer of the correct size

### DIFF
--- a/fuse/bufferpool.go
+++ b/fuse/bufferpool.go
@@ -78,7 +78,7 @@ func (p *bufferPoolImpl) AllocBuffer(size uint32) []byte {
 	pages := sz / PAGESIZE
 
 	b := p.getPool(pages).Get().([]byte)
-	return b
+	return b[:size]
 }
 
 func (p *bufferPoolImpl) FreeBuffer(slice []byte) {

--- a/fuse/bufferpool_test.go
+++ b/fuse/bufferpool_test.go
@@ -1,0 +1,15 @@
+package fuse
+
+import (
+	"testing"
+)
+
+func TestBufferPool(t *testing.T) {
+	bp := NewBufferPool()
+	size := 1500
+	buf := bp.AllocBuffer(uint32(size))
+	if len(buf) != size {
+		t.Errorf("Expected buffer of %d bytes, got %d bytes", size, len(buf))
+	}
+	bp.FreeBuffer(buf)
+}


### PR DESCRIPTION
Also add tests.

This fixes #39.