### PR TITLE
Use generation numbers properly

### DIFF
--- a/fuse/nodefs/fsmount.go
+++ b/fuse/nodefs/fsmount.go
@@ -135,7 +135,7 @@ func (m *fileSystemMount) registerFileHandle(node *Inode, dir *connectorDir, f F
 		b.WithFlags.File.SetInode(node)
 	}
 	node.openFiles = append(node.openFiles, b)
-	handle := m.openFiles.Register(&b.handled)
+	handle, _ := m.openFiles.Register(&b.handled)
 	node.openFilesMutex.Unlock()
 	return handle, b
 }

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -98,8 +98,7 @@ func (c *rawBridge) Lookup(header *fuse.InHeader, name string, out *fuse.EntryOu
 	}
 
 	child.mount.fillEntry(out)
-	out.NodeId = c.fsConn().lookupUpdate(child)
-	out.Generation = child.generation
+	out.NodeId, out.Generation = c.fsConn().lookupUpdate(child)
 	out.Ino = out.NodeId
 
 	return fuse.OK

--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -15,7 +15,7 @@ import (
 //
 // This structure is thread-safe.
 type handleMap interface {
-	Register(obj *handled) uint64
+	Register(obj *handled) (handle, generation uint64)
 	Count() int
 	Decode(uint64) *handled
 	Forget(handle uint64, count int) (bool, *handled)
@@ -57,7 +57,7 @@ func newPortableHandleMap() *portableHandleMap {
 	}
 }
 
-func (m *portableHandleMap) Register(obj *handled) (handle uint64) {
+func (m *portableHandleMap) Register(obj *handled) (handle, generation uint64) {
 	m.Lock()
 	if obj.count == 0 {
 		if obj.check != 0 {
@@ -79,7 +79,7 @@ func (m *portableHandleMap) Register(obj *handled) (handle uint64) {
 	}
 	obj.count++
 	m.Unlock()
-	return handle
+	return
 }
 
 func (m *portableHandleMap) Handle(obj *handled) (h uint64) {

--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -45,9 +45,10 @@ const _ALREADY_MSG = "Object already has a handle"
 
 type portableHandleMap struct {
 	sync.RWMutex
-	used    int
-	handles []*handled
-	freeIds []uint64
+	generation uint64
+	used       int
+	handles    []*handled
+	freeIds    []uint64
 }
 
 func newPortableHandleMap() *portableHandleMap {
@@ -70,6 +71,7 @@ func (m *portableHandleMap) Register(obj *handled) (handle, generation uint64) {
 		} else {
 			handle = m.freeIds[len(m.freeIds)-1]
 			m.freeIds = m.freeIds[:len(m.freeIds)-1]
+			m.generation++
 			m.handles[handle] = obj
 		}
 		m.used++
@@ -78,6 +80,7 @@ func (m *portableHandleMap) Register(obj *handled) (handle, generation uint64) {
 		handle = obj.handle
 	}
 	obj.count++
+	generation = m.generation
 	m.Unlock()
 	return
 }

--- a/fuse/nodefs/handle_test.go
+++ b/fuse/nodefs/handle_test.go
@@ -104,3 +104,24 @@ func TestHandleMapMultiple(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleMapGeneration(t *testing.T) {
+	hm := newPortableHandleMap()
+
+	h1, g1 := hm.Register(&handled{})
+
+	forgotten, _ := hm.Forget(h1, 1)
+	if !forgotten {
+		t.Fatalf("unref did not forget object.")
+	}
+
+	h2, g2 := hm.Register(&handled{})
+
+	if h1 != h2 {
+		t.Fatalf("register should reuse handle: got %d want %d.", h2, h1)
+	}
+
+	if g1 >= g2 {
+		t.Fatalf("register should increase generation: got %d want greater than %d.", g2, g1)
+	}
+}

--- a/fuse/nodefs/handle_test.go
+++ b/fuse/nodefs/handle_test.go
@@ -21,8 +21,8 @@ func TestHandleMapLookupCount(t *testing.T) {
 		t.Log("portable:", portable)
 		v := new(handled)
 		hm := newPortableHandleMap()
-		h1 := hm.Register(v)
-		h2 := hm.Register(v)
+		h1, _ := hm.Register(v)
+		h2, _ := hm.Register(v)
 
 		if h1 != h2 {
 			t.Fatalf("double register should reuse handle: got %d want %d.", h2, h1)
@@ -61,7 +61,7 @@ func TestHandleMapLookupCount(t *testing.T) {
 func TestHandleMapBasic(t *testing.T) {
 	v := new(handled)
 	hm := newPortableHandleMap()
-	h := hm.Register(v)
+	h, _ := hm.Register(v)
 	t.Logf("Got handle 0x%x", h)
 	if !hm.Has(h) {
 		t.Fatal("Does not have handle")
@@ -91,7 +91,7 @@ func TestHandleMapMultiple(t *testing.T) {
 	hm := newPortableHandleMap()
 	for i := 0; i < 10; i++ {
 		v := &handled{}
-		h := hm.Register(v)
+		h, _ := hm.Register(v)
 		if hm.Decode(h) != v {
 			t.Fatal("address mismatch")
 		}

--- a/fuse/nodefs/handle_test.go
+++ b/fuse/nodefs/handle_test.go
@@ -21,11 +21,15 @@ func TestHandleMapLookupCount(t *testing.T) {
 		t.Log("portable:", portable)
 		v := new(handled)
 		hm := newPortableHandleMap()
-		h1, _ := hm.Register(v)
-		h2, _ := hm.Register(v)
+		h1, g1 := hm.Register(v)
+		h2, g2 := hm.Register(v)
 
 		if h1 != h2 {
 			t.Fatalf("double register should reuse handle: got %d want %d.", h2, h1)
+		}
+
+		if g1 != g2 {
+			t.Fatalf("double register should reuse generation: got %d want %d.", g2, g1)
 		}
 
 		hm.Register(v)

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -117,7 +117,6 @@ func (n *Inode) IsDir() bool {
 func (n *Inode) NewChild(name string, isDir bool, fsi Node) *Inode {
 	ch := newInode(isDir, fsi)
 	ch.mount = n.mount
-	n.generation = ch.mount.connector.nextGeneration()
 	n.AddChild(name, ch)
 	return ch
 }

--- a/fuse/print.go
+++ b/fuse/print.go
@@ -188,8 +188,8 @@ func (me *AttrOut) string() string {
 }
 
 func (me *EntryOut) string() string {
-	return fmt.Sprintf("{%d E%d.%09d A%d.%09d %v}",
-		me.NodeId, me.EntryValid, me.EntryValidNsec,
+	return fmt.Sprintf("{%d G%d E%d.%09d A%d.%09d %v}",
+		me.NodeId, me.Generation, me.EntryValid, me.EntryValidNsec,
 		me.AttrValid, me.AttrValidNsec, &me.Attr)
 }
 


### PR DESCRIPTION
Move the generation field from nodefs/FileSystemConnector to handleMap.
Have handleMap.Register() return both the inode number and the generation number.
Increment the generation number whenever Register() reuses a previously-used node ID.
Add test.