### PR TITLE
loopback: Replace buggy syscall.NsecToTimeval()

### DIFF
--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/hanwen/go-fuse/fuse"
 )
@@ -198,6 +199,32 @@ func (f *loopbackFile) GetAttr(a *fuse.Attr) fuse.Status {
 	a.FromStat(&st)
 
 	return fuse.OK
+}
+
+const _UTIME_NOW = ((1 << 30) - 1)
+const _UTIME_OMIT = ((1 << 30) - 2)
+
+func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
+	tv := make([]syscall.Timeval, 2)
+	if a == nil {
+		tv[0].Usec = _UTIME_OMIT
+	} else {
+		n := a.UnixNano()
+		tv[0] = syscall.NsecToTimeval(n)
+	}
+
+	if m == nil {
+		tv[1].Usec = _UTIME_OMIT
+	} else {
+		n := m.UnixNano()
+		tv[1] = syscall.NsecToTimeval(n)
+	}
+
+	f.lock.Lock()
+	err := syscall.Futimes(int(f.File.Fd()), tv)
+	f.lock.Unlock()
+
+	return fuse.ToStatus(err)
 }
 
 // Allocate, Utimens implemented in files_linux.go

--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -204,30 +204,39 @@ func (f *loopbackFile) GetAttr(a *fuse.Attr) fuse.Status {
 const _UTIME_NOW = ((1 << 30) - 1)
 const _UTIME_OMIT = ((1 << 30) - 2)
 
+// timeToTimeval - Convert time.Time to syscall.Timeval
+//
+// Note: This does not use syscall.NsecToTimespec because
+// that does not work properly for times before 1970,
+// see https://github.com/golang/go/issues/12777
+func timeToTimeval(t *time.Time) syscall.Timeval {
+	var tv syscall.Timeval
+	tv.Usec = int64(t.Nanosecond() / 1000)
+	tv.Sec = t.Unix()
+	return tv
+}
+
 func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
 	tv := make([]syscall.Timeval, 2)
 	if a == nil {
 		tv[0].Usec = _UTIME_OMIT
 	} else {
-		n := a.UnixNano()
-		tv[0] = syscall.NsecToTimeval(n)
+		tv[0] = timeToTimeval(a)
 	}
 
 	if m == nil {
 		tv[1].Usec = _UTIME_OMIT
 	} else {
-		n := m.UnixNano()
-		tv[1] = syscall.NsecToTimeval(n)
+		tv[1] = timeToTimeval(m)
 	}
 
 	f.lock.Lock()
 	err := syscall.Futimes(int(f.File.Fd()), tv)
 	f.lock.Unlock()
-
 	return fuse.ToStatus(err)
 }
 
-// Allocate, Utimens implemented in files_linux.go
+// Allocate implemented in files_linux.go
 
 ////////////////////////////////////////////////////////////////
 

--- a/fuse/nodefs/files_darwin.go
+++ b/fuse/nodefs/files_darwin.go
@@ -60,29 +60,3 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 	}
 	return fuse.OK
 }
-
-const _UTIME_NOW = ((1 << 30) - 1)
-const _UTIME_OMIT = ((1 << 30) - 2)
-
-func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
-	tv := make([]syscall.Timeval, 2)
-	if a == nil {
-		tv[0].Usec = _UTIME_OMIT
-	} else {
-		n := a.UnixNano()
-		tv[0] = syscall.NsecToTimeval(n)
-	}
-
-	if m == nil {
-		tv[1].Usec = _UTIME_OMIT
-	} else {
-		n := m.UnixNano()
-		tv[1] = syscall.NsecToTimeval(n)
-	}
-
-	f.lock.Lock()
-	err := syscall.Futimes(int(f.File.Fd()), tv)
-	f.lock.Unlock()
-
-	return fuse.ToStatus(err)
-}

--- a/fuse/nodefs/files_linux.go
+++ b/fuse/nodefs/files_linux.go
@@ -2,7 +2,6 @@ package nodefs
 
 import (
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/fuse"
 )
@@ -15,29 +14,4 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 		return fuse.ToStatus(err)
 	}
 	return fuse.OK
-}
-
-const _UTIME_NOW = ((1 << 30) - 1)
-const _UTIME_OMIT = ((1 << 30) - 2)
-
-func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
-	tv := make([]syscall.Timeval, 2)
-	if a == nil {
-		tv[0].Usec = _UTIME_OMIT
-	} else {
-		n := a.UnixNano()
-		tv[0] = syscall.NsecToTimeval(n)
-	}
-
-	if m == nil {
-		tv[1].Usec = _UTIME_OMIT
-	} else {
-		n := a.UnixNano()
-		tv[1] = syscall.NsecToTimeval(n)
-	}
-
-	f.lock.Lock()
-	err := syscall.Futimes(int(f.File.Fd()), tv)
-	f.lock.Unlock()
-	return fuse.ToStatus(err)
 }

--- a/fuse/nodefs/files_test.go
+++ b/fuse/nodefs/files_test.go
@@ -1,0 +1,22 @@
+package nodefs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeToTimeval(t *testing.T) {
+	// Check that dates before 1970 are handled correctly
+	date := time.Date(1960, time.January, 1, 23, 16, 44, 650951, time.UTC)
+	tv := timeToTimeval(&date)
+	if tv.Sec != -315535396 || tv.Usec != 650 {
+		t.Fail()
+	}
+
+	// Check recent date
+	date = time.Date(2015, time.September, 29, 20, 8, 7, 74522, time.UTC)
+	tv = timeToTimeval(&date)
+	if tv.Sec != 1443557287 || tv.Usec != 74 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
syscall.NsecToTimespec does not work properly for times
before 1970, see https://github.com/golang/go/issues/12777

This caused xfstests generic/258 to fail.

Fixes issue #58.

Additionally, this fixes a bug in line 46 where `a` was used instead of `m`