### PR TITLE
init: do not kill the application if fusermount is not found

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -137,10 +137,10 @@ func init() {
 	var err error
 	fusermountBinary, err = lookPathFallback("fusermount", "/bin")
 	if err != nil {
-		log.Fatalf("Could not find fusermount binary: %v", err)
+		log.Printf("Could not find fusermount binary: %v", err)
 	}
 	umountBinary, err = lookPathFallback("umount", "/bin")
 	if err != nil {
-		log.Fatalf("Could not find umount binary: %v", err)
+		log.Printf("Could not find umount binary: %v", err)
 	}
 }


### PR DESCRIPTION
At the moment, using go-fuse in your application means that it will
exit immediately if fusermount or umount is not found.

This also prevents operations that do not use FUSE from
working - like `myapp -version` or `myapp -help`.

This is currently biting me as I test gocryptfs on Travis CI
where FUSE is not available.