### PR TITLE
Fix crash on listxattr syscall with NULL list argument.

### DIFF
--- a/fuse/pathfs/syscall_linux.go
+++ b/fuse/pathfs/syscall_linux.go
@@ -34,10 +34,12 @@ func listXAttr(path string) (attributes []string, err error) {
 		sz, err = sysListxattr(path, dest)
 	}
 
-	if sz > 0 {
-		// -1 to drop the final empty slice.
-		dest = dest[:sz-1]
+	if sz == 0 {
+		return nil, err
 	}
+
+	// -1 to drop the final empty slice.
+	dest = dest[:sz-1]
 	attributesBytes := bytes.Split(dest, []byte{0})
 	attributes = make([]string, len(attributesBytes))
 	for i, v := range attributesBytes {

--- a/fuse/pathfs/syscall_linux.go
+++ b/fuse/pathfs/syscall_linux.go
@@ -34,8 +34,10 @@ func listXAttr(path string) (attributes []string, err error) {
 		sz, err = sysListxattr(path, dest)
 	}
 
-	// -1 to drop the final empty slice.
-	dest = dest[:sz-1]
+	if sz > 0 {
+		// -1 to drop the final empty slice.
+		dest = dest[:sz-1]
+	}
 	attributesBytes := bytes.Split(dest, []byte{0})
 	attributes = make([]string, len(attributesBytes))
 	for i, v := range attributesBytes {


### PR DESCRIPTION
Steps to reproduce:
1. Run a loopback filesystem
2. Run getfattr on a file with no extended attributes.