### PR TITLE
fuse/nodefs: clear entryOut in ReadDirPlus

### DIFF
--- a/fuse/nodefs/dir.go
+++ b/fuse/nodefs/dir.go
@@ -83,11 +83,10 @@ func (d *connectorDir) ReadDirPlus(input *fuse.ReadIn, out *fuse.DirEntryList) (
 			continue
 		}
 
-		code := d.rawFS.Lookup(&input.InHeader, e.Name, entryDest)
-		if !code.Ok() {
-			// if something went wrong, clear out the entry.
-			*entryDest = fuse.EntryOut{}
-		}
+		// Clear entryDest before use it, some fields can be corrupted if does not set all fields in rawFS.Lookup
+		*entryDest = fuse.EntryOut{}
+
+		d.rawFS.Lookup(&input.InHeader, e.Name, entryDest)
 		d.lastOffset = off
 	}
 	return fuse.OK


### PR DESCRIPTION
fuse.EntryOut can be corrupted if FS implementation does not set all fileds in the Lookup of rawFS
go-mtpfs displays wrong information(ls -l) for directory(size, Nlink, ..)