### PR TITLE
fix compilation error on ubuntu-32bit

### DIFF
--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -211,13 +211,15 @@ func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
 	if a == nil {
 		ts[0].Nsec = _UTIME_OMIT
 	} else {
-		ts[0].Sec = a.Unix()
+		ts[0] = syscall.NsecToTimespec(a.UnixNano())
+		ts[0].Nsec = 0
 	}
 
 	if m == nil {
 		ts[1].Nsec = _UTIME_OMIT
 	} else {
-		ts[1].Sec = m.Unix()
+		ts[1] = syscall.NsecToTimespec(m.UnixNano())
+		ts[1].Nsec = 0
 	}
 
 	f.lock.Lock()

--- a/fuse/pathfs/loopback.go
+++ b/fuse/pathfs/loopback.go
@@ -128,13 +128,15 @@ func (fs *loopbackFileSystem) Utimens(path string, a *time.Time, m *time.Time, c
 	if a == nil {
 		ts[0].Nsec = _UTIME_OMIT
 	} else {
-		ts[0].Sec = a.Unix()
+		ts[0] = syscall.NsecToTimespec(a.UnixNano())
+		ts[0].Nsec = 0
 	}
 
 	if m == nil {
 		ts[1].Nsec = _UTIME_OMIT
 	} else {
-		ts[1].Sec = m.Unix()
+		ts[1] = syscall.NsecToTimespec(m.UnixNano())
+		ts[1].Nsec = 0
 	}
 
 	err := sysUtimensat(0, fs.GetPath(path), &ts, _AT_SYMLINK_NOFOLLOW)


### PR DESCRIPTION
time.Unix() returns int64 regardless of target platform but field of timeval is
defined as int32 values on ubuntu-32bit
NsecToTimeval has a nanosecond problem(negative value) before epoch but still can use a second field