### PR TITLE
Have pathInode.Truncate and friends use the file handle, if available

### DIFF
--- a/all.bash
+++ b/all.bash
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux
+set -eu
 
 for target in "clean" "install" ; do
   for d in fuse fuse/pathfs fuse/test zipfs unionfs \
@@ -10,13 +10,20 @@ for target in "clean" "install" ; do
     if test "${target}" = "install" && test "${d}" = "fuse/test"; then
       continue
     fi
+    echo "go ${target} github.com/hanwen/go-fuse/${d}"
     go ${target} github.com/hanwen/go-fuse/${d}
   done
 done
 
-for d in fuse zipfs unionfs
+for d in fuse zipfs unionfs fuse/test
 do
-  (cd $d && go test github.com/hanwen/go-fuse/$d && go test -race github.com/hanwen/go-fuse/$d)
+    (
+        cd $d
+        echo "go test github.com/hanwen/go-fuse/$d"
+        go test github.com/hanwen/go-fuse/$d
+        echo "go test -race github.com/hanwen/go-fuse/$d"
+        go test -race github.com/hanwen/go-fuse/$d
+    )
 done
 
 make -C benchmark


### PR DESCRIPTION
If the file handle is specified we should use it instead of
picking one at random.

Fixes #95.