### PR TITLE
Fix "Found linked inode, but Nlink == 1" bug

### DIFF
--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -339,6 +339,7 @@ func (n *pathInode) rmChild(name string) *pathInode {
 		m := n.pathFs.clientInodeMap[ch.clientInode]
 
 		idx := -1
+		// Find the entry that has us as the parent
 		for i, v := range m {
 			if v.parent == n && v.name == name {
 				idx = i
@@ -346,10 +347,14 @@ func (n *pathInode) rmChild(name string) *pathInode {
 			}
 		}
 		if idx >= 0 {
+			// Delete the "idx" entry from the middle of the slice by moving the
+			// last element over it and truncating the slice
 			m[idx] = m[len(m)-1]
 			m = m[:len(m)-1]
+			n.pathFs.clientInodeMap[ch.clientInode] = m
 		}
 		if len(m) > 0 {
+			// Reparent to a random remaining entry
 			ch.Parent = m[0].parent
 			ch.Name = m[0].name
 			return ch


### PR DESCRIPTION
Apart from adding the missing write into clientInodeMap, I have
added a few comments about what happens. Hopefully helps the
next person looking at this code.