### PR TITLE
Correctness fixes for passing xfstests generic/013 (fsstress), v2

### DIFF
--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -21,11 +21,14 @@ func main() {
 	// Scans the arg list and sets up flags
 	debug := flag.Bool("debug", false, "print debugging messages.")
 	other := flag.Bool("allow-other", false, "mount with -o allowother.")
+	enableLinks := flag.Bool("l", false, "Enable hard link support")
 	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to this file")
 	memprofile := flag.String("memprofile", "", "write memory profile to this file")
 	flag.Parse()
 	if flag.NArg() < 2 {
 		fmt.Printf("usage: %s MOUNTPOINT ORIGINAL\n", path.Base(os.Args[0]))
+		fmt.Printf("\noptions:\n")
+		flag.PrintDefaults()
 		os.Exit(2)
 	}
 	if *cpuprofile != "" {
@@ -67,7 +70,9 @@ func main() {
 		AttrTimeout:     time.Second,
 		EntryTimeout:    time.Second,
 	}
-	pathFs := pathfs.NewPathNodeFs(finalFs, nil)
+	// Enable ClientInodes so hard links work
+	pathFsOpts := &pathfs.PathNodeFsOptions{ClientInodes: *enableLinks}
+	pathFs := pathfs.NewPathNodeFs(finalFs, pathFsOpts)
 	conn := nodefs.NewFileSystemConnector(pathFs.Root(), opts)
 	mountPoint := flag.Arg(0)
 	origAbs, _ := filepath.Abs(orig)

--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -4,9 +4,9 @@
 package main
 
 import (
-	"log"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"

--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"log"
 	"flag"
 	"fmt"
 	"os"
@@ -18,6 +19,7 @@ import (
 )
 
 func main() {
+	log.SetFlags(log.Lmicroseconds)
 	// Scans the arg list and sets up flags
 	debug := flag.Bool("debug", false, "print debugging messages.")
 	other := flag.Bool("allow-other", false, "mount with -o allowother.")

--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -114,6 +114,7 @@ func (c *FileSystemConnector) lookupUpdate(node *Inode) (id, generation uint64) 
 	return
 }
 
+// forgetUpdate - decrement reference counter for "nodeID" by "forgetCount".
 // Must run outside treeLock.
 func (c *FileSystemConnector) forgetUpdate(nodeID uint64, forgetCount int) {
 	if nodeID == fuse.FUSE_ROOT_ID {

--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -118,17 +118,20 @@ func (c *FileSystemConnector) lookupUpdate(node *Inode) (id, generation uint64) 
 func (c *FileSystemConnector) forgetUpdate(nodeID uint64, forgetCount int) {
 	if nodeID == fuse.FUSE_ROOT_ID {
 		c.rootNode.Node().OnUnmount()
-
 		// We never got a lookup for root, so don't try to
 		// forget root.
 		return
 	}
 
 	if forgotten, handled := c.inodeMap.Forget(nodeID, forgetCount); forgotten {
-		node := (*Inode)(unsafe.Pointer(handled))
-		node.mount.treeLock.Lock()
-		c.recursiveConsiderDropInode(node)
-		node.mount.treeLock.Unlock()
+		inode := (*Inode)(unsafe.Pointer(handled))
+		node := inode.Node()
+		inode.mount.treeLock.RLock()
+		l := len(inode.children)
+		inode.mount.treeLock.RUnlock()
+		if l == 0 && node.Deletable() {
+			node.OnForget()
+		}
 	}
 	// TODO - try to drop children even forget was not successful.
 	c.verify()
@@ -137,39 +140,6 @@ func (c *FileSystemConnector) forgetUpdate(nodeID uint64, forgetCount int) {
 // InodeCount returns the number of inodes registered with the kernel.
 func (c *FileSystemConnector) InodeHandleCount() int {
 	return c.inodeMap.Count()
-}
-
-// Must hold treeLock.
-
-func (c *FileSystemConnector) recursiveConsiderDropInode(n *Inode) (drop bool) {
-	delChildren := []string{}
-	for k, v := range n.children {
-		// Only consider children from the same mount, or
-		// already unmounted mountpoints.
-		if v.mountPoint == nil && c.recursiveConsiderDropInode(v) {
-			delChildren = append(delChildren, k)
-		}
-	}
-	for _, k := range delChildren {
-		ch := n.rmChild(k)
-		if ch == nil {
-			log.Panicf("trying to del child %q, but not present", k)
-		}
-		ch.fsInode.OnForget()
-	}
-
-	if len(n.children) > 0 || !n.Node().Deletable() {
-		return false
-	}
-	if n == c.rootNode || n.mountPoint != nil {
-		return false
-	}
-
-	n.openFilesMutex.Lock()
-	ok := len(n.openFiles) == 0
-	n.openFilesMutex.Unlock()
-
-	return ok
 }
 
 // Finds a node within the currently known inodes, returns the last

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -68,7 +68,11 @@ func (c *FileSystemConnector) lookupMountUpdate(out *fuse.Attr, mount *fileSyste
 	return mount.mountInode, fuse.OK
 }
 
+// internalLookup - execute a lookup without affecting NodeId reference counts
 func (c *FileSystemConnector) internalLookup(out *fuse.Attr, parent *Inode, name string, header *fuse.InHeader) (node *Inode, code fuse.Status) {
+
+	// We may already know the child because it was created using Create or Mkdir
+	// or from an earlier lookup. The kernel submits new lookups periodically.
 	child := parent.GetChild(name)
 	if child != nil && child.mountPoint != nil {
 		return c.lookupMountUpdate(out, child.mountPoint)

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -70,6 +70,8 @@ func (c *FileSystemConnector) lookupMountUpdate(out *fuse.Attr, mount *fileSyste
 
 // internalLookup - execute a lookup without affecting NodeId reference counts
 func (c *FileSystemConnector) internalLookup(out *fuse.Attr, parent *Inode, name string, header *fuse.InHeader) (node *Inode, code fuse.Status) {
+	c.forgetMu.RLock()
+	defer c.forgetMu.RUnlock()
 
 	// We may already know the child because it was created using Create or Mkdir
 	// or from an earlier lookup. The kernel submits new lookups periodically.

--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -6,20 +6,27 @@ import (
 )
 
 // HandleMap translates objects in Go space to 64-bit handles that can
-// be given out to -say- the linux kernel.
+// be given out to -say- the linux kernel as NodeIds.
 //
 // The 32 bits version of this is a threadsafe wrapper around a map.
 //
-// To use it, include Handled as first member of the structure
+// To use it, include "handled" as first member of the structure
 // you wish to export.
 //
 // This structure is thread-safe.
 type handleMap interface {
+	// Register - store "obj" and return a unique (NodeId, generation) tuple
 	Register(obj *handled) (handle, generation uint64)
 	Count() int
+	// Decode - retrieve object from its 64-bit handle
 	Decode(uint64) *handled
+	// Forget - decrement reference counter for "handle" by "count" and drop
+	// the object if the refcount reaches zero.
+	// Returns a boolean whether the object was dropped and the object itself.
 	Forget(handle uint64, count int) (bool, *handled)
+	// Handle - get the object's NodeId
 	Handle(obj *handled) uint64
+	// Has - check if NodeId is stored
 	Has(uint64) bool
 }
 
@@ -45,10 +52,15 @@ const _ALREADY_MSG = "Object already has a handle"
 
 type portableHandleMap struct {
 	sync.RWMutex
+	// The generation counter is incremented each time a NodeId is reused,
+	// hence the (NodeId, Generation) tuple is always unique.
 	generation uint64
-	used       int
-	handles    []*handled
-	freeIds    []uint64
+	// Number of currently used handles
+	used int
+	// Array of Go objects indexed by NodeId
+	handles []*handled
+	// Free slots in the "handles" array
+	freeIds []uint64
 }
 
 func newPortableHandleMap() *portableHandleMap {

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -157,6 +157,7 @@ func (n *Inode) RmChild(name string) (ch *Inode) {
 //////////////////////////////////////////////////////////////
 // private
 
+// addChild - Add "child" to our children under name "name".
 // Must be called with treeLock for the mount held.
 func (n *Inode) addChild(name string, child *Inode) {
 	if paranoia {
@@ -168,6 +169,7 @@ func (n *Inode) addChild(name string, child *Inode) {
 	n.children[name] = child
 }
 
+// rmChild - Drop "name" from our children
 // Must be called with treeLock for the mount held.
 func (n *Inode) rmChild(name string) (ch *Inode) {
 	ch = n.children[name]

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -113,7 +113,7 @@ func (n *Inode) IsDir() bool {
 	return n.children != nil
 }
 
-// NewChild adds a new child inode to this inode.
+// NewChild creates an Inode, sets that Inode using fsi.SetInode() and calls AddChild.
 func (n *Inode) NewChild(name string, isDir bool, fsi Node) *Inode {
 	ch := newInode(isDir, fsi)
 	ch.mount = n.mount
@@ -131,11 +131,14 @@ func (n *Inode) GetChild(name string) (child *Inode) {
 	return child
 }
 
-// AddChild adds a child inode. The parent inode must be a directory
-// node.
+// AddChild adds an existing "*Inode" as a child to ourself, under the name "name".
+// Panics for non-directory Inodes.
 func (n *Inode) AddChild(name string, child *Inode) {
 	if child == nil {
 		log.Panicf("adding nil child as %q", name)
+	}
+	if !n.IsDir() {
+		log.Panicf("adding child %q to non-directory", name)
 	}
 	n.mount.treeLock.Lock()
 	n.addChild(name, child)

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -229,6 +229,7 @@ func doGetAttr(server *Server, req *request) {
 	req.status = s
 }
 
+// doForget - forget one NodeId
 func doForget(server *Server, req *request) {
 	if !server.opts.RememberInodes {
 		server.forgetMu.Lock()
@@ -237,6 +238,7 @@ func doForget(server *Server, req *request) {
 	}
 }
 
+// doBatchForget - forget a list of NodeIds
 func doBatchForget(server *Server, req *request) {
 	server.forgetMu.Lock()
 	defer server.forgetMu.Unlock()

--- a/fuse/print.go
+++ b/fuse/print.go
@@ -93,11 +93,11 @@ func FlagString(names map[int64]string, fl int64, def string) string {
 }
 
 func (me *ForgetIn) string() string {
-	return fmt.Sprintf("{%d}", me.Nlookup)
+	return fmt.Sprintf("{Nlookup=%d}", me.Nlookup)
 }
 
 func (me *_BatchForgetIn) string() string {
-	return fmt.Sprintf("{%d}", me.Count)
+	return fmt.Sprintf("{Count=%d}", me.Count)
 }
 
 func (me *MkdirIn) string() string {
@@ -195,6 +195,7 @@ func (me *AttrOut) string() string {
 		me.AttrValid, me.AttrValidNsec, &me.Attr)
 }
 
+// Returned by LOOKUP
 func (me *EntryOut) string() string {
 	return fmt.Sprintf("{NodeId: %d Generation=%d EntryValid=%d.%03d AttrValid=%d.%03d Attr=%v}",
 		me.NodeId, me.Generation, me.EntryValid, me.EntryValidNsec/1000000,

--- a/fuse/print.go
+++ b/fuse/print.go
@@ -196,13 +196,13 @@ func (me *AttrOut) string() string {
 }
 
 func (me *EntryOut) string() string {
-	return fmt.Sprintf("{%d G%d E%d.%09d A%d.%09d %v}",
-		me.NodeId, me.Generation, me.EntryValid, me.EntryValidNsec,
-		me.AttrValid, me.AttrValidNsec, &me.Attr)
+	return fmt.Sprintf("{NodeId: %d Generation=%d EntryValid=%d.%03d AttrValid=%d.%03d Attr=%v}",
+		me.NodeId, me.Generation, me.EntryValid, me.EntryValidNsec/1000000,
+		me.AttrValid, me.AttrValidNsec/1000000, &me.Attr)
 }
 
 func (me *CreateOut) string() string {
-	return fmt.Sprintf("{%v %v}", &me.EntryOut, &me.OpenOut)
+	return fmt.Sprintf("{NodeId: %d Generation=%d %v %v}", me.NodeId, me.Generation, &me.EntryOut, &me.OpenOut)
 }
 
 func (me *StatfsOut) string() string {
@@ -227,6 +227,10 @@ func (o *NotifyInvalDeleteOut) string() string {
 func (f *FallocateIn) string() string {
 	return fmt.Sprintf("{Fh %d off %d sz %d mod 0%o}",
 		f.Fh, f.Offset, f.Length, f.Mode)
+}
+
+func (f *LinkIn) string() string {
+	return fmt.Sprintf("{Oldnodeid: %d}", f.Oldnodeid)
 }
 
 // Print pretty prints FUSE data types for kernel communication

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -28,21 +28,6 @@ type Server struct {
 	// writeMu serializes close and notify writes
 	writeMu sync.Mutex
 
-	// forgetMu prevents concurrent execution of FORGET, BATCH_FORGET
-	// and LOOKUP. The problem is:
-	//
-	// Thread 1            Thread 2
-	// ----------------    -------------------
-	// BATCH_FORGET 1,2
-	// --> forget 1
-	//                     LOOKUP "foo"
-	//                     --> return NodeId 2
-	// --> forget 2
-	//
-	// At this point the kernel holds a reference to NodeId 2 that has
-	// been forgotten inside go-fuse.
-	forgetMu sync.RWMutex
-
 	// I/O with kernel and daemon.
 	mountFd int
 

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -28,6 +28,21 @@ type Server struct {
 	// writeMu serializes close and notify writes
 	writeMu sync.Mutex
 
+	// forgetMu prevents concurrent execution of FORGET, BATCH_FORGET
+	// and LOOKUP. The problem is:
+	//
+	// Thread 1            Thread 2
+	// ----------------    -------------------
+	// BATCH_FORGET 1,2
+	// --> forget 1
+	//                     LOOKUP "foo"
+	//                     --> return NodeId 2
+	// --> forget 2
+	//
+	// At this point the kernel holds a reference to NodeId 2 that has
+	// been forgotten inside go-fuse.
+	forgetMu sync.RWMutex
+
 	// I/O with kernel and daemon.
 	mountFd int
 

--- a/unionfs/unionfs.go
+++ b/unionfs/unionfs.go
@@ -346,22 +346,14 @@ func (fs *unionFS) Promote(name string, srcResult branchResult, context *fuse.Co
 ////////////////////////////////////////////////////////////////
 // Below: implement interface for a FileSystem.
 
+// Link - create a hard link named "newName" to "orig".
+// If "orig" is on a read-only branch it will be promoted to read-write as
+// hard links only work in the read-write branch.
 func (fs *unionFS) Link(orig string, newName string, context *fuse.Context) (code fuse.Status) {
 	origResult := fs.getBranch(orig)
 	code = origResult.code
 	if code.Ok() && origResult.branch > 0 {
 		code = fs.Promote(orig, origResult, context)
-	}
-	if code.Ok() && origResult.branch > 0 {
-		// Hairy: for the link to be hooked up to the existing
-		// inode, PathNodeFs must see a client inode for the
-		// original.  We force a refresh of the attribute (so
-		// the Ino is filled in.), and then force PathNodeFs
-		// to see the Inode number.
-		fs.branchCache.GetFresh(orig)
-		inode := fs.nodeFs.Node(orig)
-		var a fuse.Attr
-		inode.Node().GetAttr(&a, nil, nil)
 	}
 	if code.Ok() {
 		code = fs.promoteDirsTo(newName)
@@ -370,6 +362,9 @@ func (fs *unionFS) Link(orig string, newName string, context *fuse.Context) (cod
 		code = fs.fileSystems[0].Link(orig, newName, context)
 	}
 	if code.Ok() {
+		// Inode number has changed from 0 to an actual inode number
+		fs.branchCache.DropEntry(orig)
+
 		fs.removeDeletion(newName)
 		fs.branchCache.GetFresh(newName)
 	}
@@ -661,12 +656,10 @@ func (fs *unionFS) Create(name string, flags uint32, mode uint32, context *fuse.
 		fuseFile = fs.newUnionFsFile(fuseFile, 0)
 		fs.removeDeletion(name)
 
-		now := time.Now()
-		a := fuse.Attr{
-			Mode: fuse.S_IFREG | mode,
+		a, code := writable.GetAttr(name, context)
+		if code.Ok() {
+			fs.branchCache.Set(name, branchResult{a, fuse.OK, 0})
 		}
-		a.SetTimes(nil, &now, &now)
-		fs.branchCache.Set(name, branchResult{&a, fuse.OK, 0})
 	}
 	return fuseFile, code
 }
@@ -948,9 +941,8 @@ func (fs *unionFS) Open(name string, flags uint32, context *fuse.Context) (fuseF
 			return nil, code
 		}
 		r.branch = 0
-		now := time.Now()
-		r.attr.SetTimes(nil, &now, nil)
-		fs.branchCache.Set(name, r)
+		// Timestamps and inode number have changed. Drop the entry from the cache.
+		fs.branchCache.DropEntry(name)
 	}
 	fuseFile, status = fs.fileSystems[r.branch].Open(name, uint32(flags), context)
 	if fuseFile != nil {

--- a/unionfs/unionfs_test.go
+++ b/unionfs/unionfs_test.go
@@ -51,13 +51,15 @@ func setRecursiveWritable(t *testing.T, dir string, writable bool) {
 	}
 }
 
-// Creates 3 directories on a temporary dir: /mnt with the overlayed
-// (unionfs) mount, rw with modifiable data, and ro on the bottom.
-func setupUfs(t *testing.T) (workdir string, cleanup func()) {
+// Creates a temporary dir "wd" with 3 directories:
+// mnt ... overlayed (unionfs) mount
+// rw .... modifiable data
+// ro .... read-only data
+func setupUfs(t *testing.T) (wd string, cleanup func()) {
 	// Make sure system setting does not affect test.
 	syscall.Umask(0)
 
-	wd, _ := ioutil.TempDir("", "unionfs")
+	wd, _ = ioutil.TempDir("", "unionfs")
 	err := os.Mkdir(wd+"/mnt", 0700)
 	if err != nil {
 		t.Fatalf("Mkdir failed: %v", err)

--- a/unionfs/unionfs_test.go
+++ b/unionfs/unionfs_test.go
@@ -1504,10 +1504,7 @@ func TestUnionFSBarf(t *testing.T) {
 	if err := os.Rename(wd+"/rw/dir/file", wd+"/rw/file"); err != nil {
 		t.Fatalf("os.Rename: %v", err)
 	}
-
-	err := os.Rename(wd+"/mnt/file", wd+"/mnt/dir2/file")
-	if fuse.ToStatus(err) != fuse.ENOENT {
-		// TODO - this should just succeed?
+	if err := os.Rename(wd+"/mnt/file", wd+"/mnt/dir2/file"); err != nil {
 		t.Fatalf("os.Rename: %v", err)
 	}
 }


### PR DESCRIPTION
v2 of the patch series consolidates the changes into fewer patches and skips some intrusive unionfs changes. The clientinode handling is not factored out into its own file but integrated more tightly into pathfs, together with the new "parents" map. This may come at a performance cost for everybody not using hard links, but the returns is a simpler code base. My canonical gocryptfs benchmark (hard links enabled) showed no measurable changes whatsover.
As with v1, loopbackfs not passes thousands of iterations.