### PR TITLE
nodefs: fix chgrp

### DIFF
--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -201,7 +201,15 @@ func (c *rawBridge) SetAttr(input *fuse.SetAttrIn, out *fuse.AttrOut) (code fuse
 		code = node.fsInode.Chmod(f, permissions, &input.Context)
 	}
 	if code.Ok() && (input.Valid&(fuse.FATTR_UID|fuse.FATTR_GID) != 0) {
-		code = node.fsInode.Chown(f, uint32(input.Uid), uint32(input.Gid), &input.Context)
+		var uid uint32 = ^uint32(0) // means "do not change" in chown(2)
+		var gid uint32 = ^uint32(0)
+		if input.Valid&fuse.FATTR_UID != 0 {
+			uid = input.Uid
+		}
+		if input.Valid&fuse.FATTR_GID != 0 {
+			gid = input.Gid
+		}
+		code = node.fsInode.Chown(f, uid, gid, &input.Context)
 	}
 	if code.Ok() && input.Valid&fuse.FATTR_SIZE != 0 {
 		code = node.fsInode.Truncate(f, input.Size, &input.Context)

--- a/fuse/test/loopback_test.go
+++ b/fuse/test/loopback_test.go
@@ -940,3 +940,20 @@ func TestSpecialEntries(t *testing.T) {
 		t.Errorf("directory is empty, entries '.' and '..' are missing")
 	}
 }
+
+// Check that chgrp(1) works
+func TestChgrp(t *testing.T) {
+	tc := NewTestCase(t)
+	defer tc.Cleanup()
+
+	f, err := os.Create(tc.mnt + "/file")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	defer f.Close()
+
+	err = f.Chown(-1, os.Getgid())
+	if err != nil {
+		t.Errorf("Chown failed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/hanwen/go-fuse/issues/107 .

Uses `^uint32(0)` as a uint32 substitute for `-1`.