### PR TITLE
loopback: use AT_FDCWD in utimensat call

### DIFF
--- a/fuse/pathfs/loopback.go
+++ b/fuse/pathfs/loopback.go
@@ -25,6 +25,12 @@ type loopbackFileSystem struct {
 // system.  Its main purpose is to provide test coverage without
 // having to build a synthetic filesystem.
 func NewLoopbackFileSystem(root string) FileSystem {
+	// Make sure the Root path is absolute to avoid problems when the
+	// application changes working directory.
+	root, err := filepath.Abs(root)
+	if err != nil {
+		panic(err)
+	}
 	return &loopbackFileSystem{
 		FileSystem: NewDefaultFileSystem(),
 		Root:       root,


### PR DESCRIPTION
When mounting using relative paths, "touch" on directories fails:

  $ loopback b a &
  $ cd b
  $ mkdir foo
  $ touch foo
  touch: setting times of 'foo': Not a directory

strace:

  [pid 30185] utimensat(0, "a/foo", [{1468441847, 0}, {1468441847, 0}], AT_SYMLINK_NOFOLLOW <unfinished ...>
  [...]
  [pid 30185] <... utimensat resumed> )   = -1 ENOTDIR (Not a directory)

Change-Id: If78f67fd8cfee946bf1a1112b81dd7fe959afe2b