### PR TITLE
fix spurious failures due to unexpected mountFd closure

### DIFF
--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -61,7 +61,10 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 		ready <- err
 		close(ready)
 	}()
-	return int(f.Fd()), nil
+
+	// The finalizer for f will close its fd so we return a dup.
+	defer f.Close()
+	return syscall.Dup(int(f.Fd()))
 }
 
 func unmount(dir string) error {


### PR DESCRIPTION
I synced up recently and was seeing this error on Darwin:

```
2016/07/31 01:16:54 Dispatch 1: WRITE, NodeId: 10.  65536 bytes
2016/07/31 01:16:54 Serialize 1: WRITE code: OK value: 
2016/07/31 01:16:54 writer: Write/Writev failed, err: 9=bad file descriptor. opcode: WRITE
2016/07/31 01:16:54 Failed to read from fuse conn: 9=bad file descriptor
```

I suspected that someone was closing the fd unexpectedly. I confirmed this with a little DTrace script:

```
syscall::write*:entry
/execname == "nomsfs" && arg0 == 11/
{
    trace(arg0);
    self->yes = 1;
}

syscall::write*:return
/self->yes/
{
    printf("%d %d", arg1, errno);
    self->yes = 0;
}

syscall::close:entry
/execname == "nomsfs" && arg0 == 11/
{}
```

This showed a `close` preceding the failing `write` and then another `close` on the same fd in the exit path. Unfortunately with no frame pointers I couldn't get a stack trace easily. Looking at the source for `os.File` I found this in:

```
func NewFile(fd uintptr, name string) *File {
	fdi := int(fd)
	if fdi < 0 {
		return nil
	}
	f := &File{&file{fd: fdi, name: name}}
	runtime.SetFinalizer(f.file, (*file).close)
	return f
}
```

My fs allocates a bunch so perhaps the memory pressure caused this to run, bringing down the system. The patch is intended to be minimally invasive. It's been running for about an hour whereas without the patch it would die in a few seconds.