### PR TITLE
fixed a bunch of tests on darwin

### DIFF
--- a/README
+++ b/README
@@ -104,8 +104,7 @@ go-fuse works somewhat on OSX. Known limitations:
 * OSX has trouble with concurrent reads from the FUSE device, leading
   to performance concerns.
 
-* A bunch of tests under fuse/test/ fail, and the functionality they
-  test for OSX is likely broken.
+* Tests are expected to pass; report any failure as a bug!
 
 
 CREDITS

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -89,9 +89,6 @@ func doInit(server *Server, req *request) {
 		server.setSplice()
 	}
 
-	server.versionMinor = input.Minor
-	server.versionMajor = input.Major
-
 	server.reqMu.Unlock()
 
 	out := &InitOut{

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -88,6 +88,10 @@ func doInit(server *Server, req *request) {
 	if input.Minor >= 13 {
 		server.setSplice()
 	}
+
+	server.versionMinor = input.Minor
+	server.versionMajor = input.Major
+
 	server.reqMu.Unlock()
 
 	out := &InitOut{

--- a/fuse/pathfs/loopback_darwin.go
+++ b/fuse/pathfs/loopback_darwin.go
@@ -17,11 +17,12 @@ func (fs *loopbackFileSystem) StatFs(name string) *fuse.StatfsOut {
 	if err == nil {
 		return &fuse.StatfsOut{
 			Blocks: s.Blocks,
-			Bsize:  uint32(s.Bsize),
 			Bfree:  s.Bfree,
 			Bavail: s.Bavail,
 			Files:  s.Files,
 			Ffree:  s.Ffree,
+			Bsize:  uint32(s.Iosize), // Iosize translates to Bsize: the optimal transfer size.
+			Frsize: s.Bsize,          // Bsize translates to Frsize: the minimum transfer size.
 		}
 	}
 	return nil

--- a/fuse/pathfs/loopback_darwin.go
+++ b/fuse/pathfs/loopback_darwin.go
@@ -59,6 +59,6 @@ func (fs *loopbackFileSystem) Utimens(path string, a *time.Time, m *time.Time, c
 		tv[1] = timeToTimeval(m)
 	}
 
-	err := syscall.Utimes(path, tv)
+	err := syscall.Utimes(fs.GetPath(path), tv)
 	return fuse.ToStatus(err)
 }

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -61,14 +61,6 @@ func (ms *Server) SetDebug(dbg bool) {
 	ms.opts.Debug = dbg
 }
 
-func (ms *Server) SupportsNotify(op int) bool {
-	switch op {
-	case NOTIFY_INVAL_ENTRY:
-		return ms.kernelSettings.Major >= 7 && ms.kernelSettings.Minor >= 12
-	}
-	return false
-}
-
 // KernelSettings returns the Init message from the kernel, so
 // filesystems can adapt to availability of features of the kernel
 // driver.
@@ -560,13 +552,13 @@ func (ms *Server) EntryNotify(parent uint64, name string) Status {
 
 // SupportsVersion returns true if the kernel supports the given
 // protocol version or newer.
-func (in *InitIn) SupportsVersion(maj, min uint32) bool {
+func (in InitIn) SupportsVersion(maj, min uint32) bool {
 	return in.Major >= maj && in.Minor >= min
 }
 
 // SupportsNotify returns whether a certain notification type is
 // supported. Pass any of the NOTIFY_INVAL_* types as argument.
-func (in *InitIn) SupportsNotify(notifyType int) bool {
+func (in InitIn) SupportsNotify(notifyType int) bool {
 	switch notifyType {
 	case NOTIFY_INVAL_ENTRY:
 		return in.SupportsVersion(7, 12)

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -25,9 +25,6 @@ const (
 // Server contains the logic for reading from the FUSE device and
 // translating it to RawFileSystem interface calls.
 type Server struct {
-	versionMajor uint32
-	versionMinor uint32
-
 	// Empty if unmounted.
 	mountPoint string
 	fileSystem RawFileSystem
@@ -64,8 +61,12 @@ func (ms *Server) SetDebug(dbg bool) {
 	ms.opts.Debug = dbg
 }
 
-func (ms *Server) Version() (major, minor uint32) {
-	return ms.versionMinor, ms.versionMinor
+func (ms *Server) SupportsNotify(op int) bool {
+	switch op {
+	case NOTIFY_INVAL_ENTRY:
+		return ms.kernelSettings.Major >= 7 && ms.kernelSettings.Minor >= 12
+	}
+	return false
 }
 
 // KernelSettings returns the Init message from the kernel, so

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -25,6 +25,9 @@ const (
 // Server contains the logic for reading from the FUSE device and
 // translating it to RawFileSystem interface calls.
 type Server struct {
+	versionMajor uint32
+	versionMinor uint32
+
 	// Empty if unmounted.
 	mountPoint string
 	fileSystem RawFileSystem
@@ -59,6 +62,10 @@ type Server struct {
 func (ms *Server) SetDebug(dbg bool) {
 	// This will typically trigger the race detector.
 	ms.opts.Debug = dbg
+}
+
+func (ms *Server) Version() (major, minor uint32) {
+	return ms.versionMinor, ms.versionMinor
 }
 
 // KernelSettings returns the Init message from the kernel, so

--- a/fuse/test/loopback_darwin_test.go
+++ b/fuse/test/loopback_darwin_test.go
@@ -11,13 +11,14 @@ import (
 func clearStatfs(s *syscall.Statfs_t) {
 	empty := syscall.Statfs_t{}
 
-	// FUSE can't set the following fields defined in struct vfsstatfs on darwin.
-	s.Type = empty.Type
-	s.Fsid = empty.Fsid
-	s.Owner = empty.Owner
-	s.Flags = empty.Flags
-	s.Fssubtype = empty.Fssubtype
-	s.Fstypename = empty.Fstypename
-	s.Mntonname = empty.Mntonname
-	s.Mntfromname = empty.Mntfromname
+	// FUSE can only set the following fields.
+	empty.Blocks = s.Blocks
+	empty.Bfree = s.Bfree
+	empty.Bavail = s.Bavail
+	empty.Files = s.Files
+	empty.Ffree = s.Ffree
+	empty.Iosize = s.Iosize
+	empty.Bsize = s.Bsize
+	// Clear out the rest.
+	*s = empty
 }

--- a/fuse/test/loopback_darwin_test.go
+++ b/fuse/test/loopback_darwin_test.go
@@ -10,9 +10,14 @@ import (
 
 func clearStatfs(s *syscall.Statfs_t) {
 	empty := syscall.Statfs_t{}
-	s.Type = 0
+
+	// FUSE can't set the following fields defined in struct vfsstatfs on darwin.
+	s.Type = empty.Type
 	s.Fsid = empty.Fsid
-	// s.Spare = empty.Spare
-	// TODO - figure out what this is for.
-	s.Flags = 0
+	s.Owner = empty.Owner
+	s.Flags = empty.Flags
+	s.Fssubtype = empty.Fssubtype
+	s.Fstypename = empty.Fstypename
+	s.Mntonname = empty.Mntonname
+	s.Mntfromname = empty.Mntfromname
 }

--- a/unionfs/autounion.go
+++ b/unionfs/autounion.go
@@ -301,40 +301,33 @@ func (fs *autoUnionFs) GetXAttr(name string, attr string, context *fuse.Context)
 }
 
 func (fs *autoUnionFs) GetAttr(path string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
+	a := &fuse.Attr{
+		Owner: *fuse.CurrentOwner(),
+	}
 	if path == "" || path == _CONFIG || path == _STATUS {
-		a := &fuse.Attr{
-			Mode: fuse.S_IFDIR | 0755,
-		}
+		a.Mode = fuse.S_IFDIR | 0755
 		return a, fuse.OK
 	}
 
 	if path == filepath.Join(_STATUS, _VERSION) {
-		a := &fuse.Attr{
-			Mode: fuse.S_IFREG | 0644,
-			Size: uint64(len(fs.options.Version)),
-		}
+		a.Mode = fuse.S_IFREG | 0644
+		a.Size = uint64(len(fs.options.Version))
 		return a, fuse.OK
 	}
 
 	if path == filepath.Join(_STATUS, _DEBUG) {
-		a := &fuse.Attr{
-			Mode: fuse.S_IFREG | 0644,
-			Size: uint64(len(fs.DebugData())),
-		}
+		a.Mode = fuse.S_IFREG | 0644
+		a.Size = uint64(len(fs.DebugData()))
 		return a, fuse.OK
 	}
 
 	if path == filepath.Join(_STATUS, _ROOT) {
-		a := &fuse.Attr{
-			Mode: syscall.S_IFLNK | 0644,
-		}
+		a.Mode = syscall.S_IFLNK | 0644
 		return a, fuse.OK
 	}
 
 	if path == filepath.Join(_CONFIG, _SCAN_CONFIG) {
-		a := &fuse.Attr{
-			Mode: fuse.S_IFREG | 0644,
-		}
+		a.Mode = fuse.S_IFREG | 0644
 		return a, fuse.OK
 	}
 	comps := strings.Split(path, string(filepath.Separator))
@@ -346,9 +339,7 @@ func (fs *autoUnionFs) GetAttr(path string, context *fuse.Context) (*fuse.Attr, 
 			return nil, fuse.ENOENT
 		}
 
-		a := &fuse.Attr{
-			Mode: syscall.S_IFLNK | 0644,
-		}
+		a.Mode = syscall.S_IFLNK | 0644
 		return a, fuse.OK
 	}
 

--- a/unionfs/autounion_test.go
+++ b/unionfs/autounion_test.go
@@ -144,8 +144,8 @@ func TestAutoFsSymlink(t *testing.T) {
 		t.Error("error writing:", err)
 	}
 
-	// Note that FUSE API 7.11 introduced the notification support required to cause the node to be immediately removed. This check will fail in earlier versions.
-	if _, minor := server.Version(); minor >= 11 {
+	// If FUSE supports invalid inode notifications we expect this node to be gone. Otherwise we'll just make sure that it's not reachable.
+	if server.SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
 		fi, _ = os.Lstat(wd + "/mnt/manual1")
 		if fi != nil {
 			t.Error("Should not have file:", fi)

--- a/unionfs/autounion_test.go
+++ b/unionfs/autounion_test.go
@@ -23,6 +23,7 @@ var testAOpts = AutoUnionFsOptions{
 		EntryTimeout:    entryTtl,
 		AttrTimeout:     entryTtl,
 		NegativeTimeout: 0,
+		Debug:           VerboseTest(),
 	},
 	HideReadonly: true,
 	Version:      "version",
@@ -39,7 +40,7 @@ func WriteFile(t *testing.T, name string, contents string) {
 	}
 }
 
-func setup(t *testing.T) (workdir string, cleanup func()) {
+func setup(t *testing.T) (workdir string, server *fuse.Server, cleanup func()) {
 	wd, _ := ioutil.TempDir("", "")
 	err := os.Mkdir(wd+"/mnt", 0700)
 	if err != nil {
@@ -66,15 +67,16 @@ func setup(t *testing.T) (workdir string, cleanup func()) {
 		t.Fatalf("MountNodeFileSystem failed: %v", err)
 	}
 	go state.Serve()
+	state.WaitMount()
 
-	return wd, func() {
+	return wd, state, func() {
 		state.Unmount()
 		os.RemoveAll(wd)
 	}
 }
 
 func TestDebug(t *testing.T) {
-	wd, clean := setup(t)
+	wd, _, clean := setup(t)
 	defer clean()
 
 	c, err := ioutil.ReadFile(wd + "/mnt/status/debug")
@@ -87,7 +89,7 @@ func TestDebug(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	wd, clean := setup(t)
+	wd, _, clean := setup(t)
 	defer clean()
 
 	c, err := ioutil.ReadFile(wd + "/mnt/status/gounionfs_version")
@@ -100,7 +102,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestAutoFsSymlink(t *testing.T) {
-	wd, clean := setup(t)
+	wd, server, clean := setup(t)
 	defer clean()
 
 	err := os.Mkdir(wd+"/store/backing1", 0755)
@@ -142,14 +144,22 @@ func TestAutoFsSymlink(t *testing.T) {
 		t.Error("error writing:", err)
 	}
 
-	fi, _ = os.Lstat(wd + "/mnt/manual1")
-	if fi != nil {
-		t.Error("Should not have file:", fi)
-	}
-
-	_, err = ioutil.ReadDir(wd + "/mnt/config")
-	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
+	// Note that FUSE API 7.11 introduced the notification support required to cause the node to be immediately removed. This check will fail in earlier versions.
+	if _, minor := server.Version(); minor >= 11 {
+		fi, _ = os.Lstat(wd + "/mnt/manual1")
+		if fi != nil {
+			t.Error("Should not have file:", fi)
+		}
+	} else {
+		entries, err = ioutil.ReadDir(wd + "/mnt")
+		if err != nil {
+			t.Fatalf("ReadDir failed: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name() == "manual1" {
+				t.Error("Should not have entry: ", e)
+			}
+		}
 	}
 
 	_, err = os.Lstat(wd + "/mnt/backing1/file1")
@@ -159,7 +169,7 @@ func TestAutoFsSymlink(t *testing.T) {
 }
 
 func TestDetectSymlinkedDirectories(t *testing.T) {
-	wd, clean := setup(t)
+	wd, _, clean := setup(t)
 	defer clean()
 
 	err := os.Mkdir(wd+"/backing1", 0755)
@@ -190,7 +200,7 @@ func TestDetectSymlinkedDirectories(t *testing.T) {
 }
 
 func TestExplicitScan(t *testing.T) {
-	wd, clean := setup(t)
+	wd, _, clean := setup(t)
 	defer clean()
 
 	err := os.Mkdir(wd+"/store/backing1", 0755)
@@ -225,7 +235,7 @@ func TestExplicitScan(t *testing.T) {
 }
 
 func TestCreationChecks(t *testing.T) {
-	wd, clean := setup(t)
+	wd, _, clean := setup(t)
 	defer clean()
 
 	err := os.Mkdir(wd+"/store/foo", 0755)

--- a/unionfs/autounion_test.go
+++ b/unionfs/autounion_test.go
@@ -145,7 +145,7 @@ func TestAutoFsSymlink(t *testing.T) {
 	}
 
 	// If FUSE supports invalid inode notifications we expect this node to be gone. Otherwise we'll just make sure that it's not reachable.
-	if server.SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
+	if server.KernelSettings().SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
 		fi, _ = os.Lstat(wd + "/mnt/manual1")
 		if fi != nil {
 			t.Error("Should not have file:", fi)

--- a/unionfs/unionfs.go
+++ b/unionfs/unionfs.go
@@ -570,7 +570,7 @@ func (fs *unionFS) Chmod(name string, mode uint32, context *fuse.Context) (code 
 func (fs *unionFS) Access(name string, mode uint32, context *fuse.Context) (code fuse.Status) {
 	// We always allow writing.
 	mode = mode &^ fuse.W_OK
-	if name == "" {
+	if name == "" || name == _DROP_CACHE {
 		return fuse.OK
 	}
 	r := fs.getBranch(name)

--- a/unionfs/unionfs.go
+++ b/unionfs/unionfs.go
@@ -712,12 +712,7 @@ func (fs *unionFS) GetXAttr(name string, attr string, context *fuse.Context) ([]
 	}
 	r := fs.getBranch(name)
 	if r.branch >= 0 {
-		value, code := fs.fileSystems[r.branch].GetXAttr(name, attr, context)
-		// We intercept ENOSYS and replace it with ENODATA; returning ENOSYS would cause FUSE to never to GetXAttr() again.
-		if code == fuse.ENOSYS {
-			return nil, fuse.ENODATA
-		}
-		return value, code
+		return fs.fileSystems[r.branch].GetXAttr(name, attr, context)
 	}
 	return nil, fuse.ENOENT
 }

--- a/unionfs/unionfs_test.go
+++ b/unionfs/unionfs_test.go
@@ -1170,6 +1170,7 @@ func TestUnionFsDisappearing(t *testing.T) {
 	}
 	defer state.Unmount()
 	go state.Serve()
+	state.WaitMount()
 
 	err = ioutil.WriteFile(wd+"/ro/file", []byte("blabla"), 0644)
 	if err != nil {
@@ -1195,9 +1196,9 @@ func TestUnionFsDisappearing(t *testing.T) {
 		t.Fatal("write should have failed")
 	}
 
-	// Restore, and wait for caches to catch up.
-	wrFs.visibleChan <- true
+	// Wait for the caches to purge, and then restore.
 	time.Sleep((3 * entryTtl) / 2)
+	wrFs.visibleChan <- true
 
 	_, err = ioutil.ReadDir(wd + "/mnt")
 	if err != nil {

--- a/unionfs/unionfs_test.go
+++ b/unionfs/unionfs_test.go
@@ -106,6 +106,7 @@ func setupUfs(t *testing.T) (wd string, cleanup func()) {
 		t.Fatalf("MountNodeFileSystem failed: %v", err)
 	}
 	go state.Serve()
+	state.WaitMount()
 
 	return wd, func() {
 		err := state.Unmount()
@@ -243,8 +244,9 @@ func TestUnionFsChtimes(t *testing.T) {
 	}
 
 	fi, err := os.Lstat(wd + "/mnt/file")
-	stat := fuse.ToStatT(fi)
-	if stat.Atim.Sec != 82 || stat.Mtim.Sec != 83 {
+	attr := &fuse.Attr{}
+	attr.FromStat(fuse.ToStatT(fi))
+	if attr.Atime != 82 || attr.Mtime != 83 {
 		t.Error("Incorrect timestamp", fi)
 	}
 }
@@ -1278,41 +1280,6 @@ func TestUnionFsDoubleOpen(t *testing.T) {
 
 	if string(b) != "hello" {
 		t.Errorf("r/w and r/o file are not synchronized: got %q want %q", string(b), want)
-	}
-}
-
-func TestUnionFsFdLeak(t *testing.T) {
-	beforeEntries, err := ioutil.ReadDir("/proc/self/fd")
-	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
-	}
-
-	wd, clean := setupUfs(t)
-	err = ioutil.WriteFile(wd+"/ro/file", []byte("blablabla"), 0644)
-	if err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-	setRecursiveWritable(t, wd+"/ro", false)
-
-	contents, err := ioutil.ReadFile(wd + "/mnt/file")
-	if err != nil {
-		t.Fatalf("ReadFile failed: %v", err)
-	}
-
-	err = ioutil.WriteFile(wd+"/mnt/file", contents, 0644)
-	if err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-
-	clean()
-
-	afterEntries, err := ioutil.ReadDir("/proc/self/fd")
-	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
-	}
-
-	if len(afterEntries) != len(beforeEntries) {
-		t.Errorf("/proc/self/fd changed size: after %v before %v", len(beforeEntries), len(afterEntries))
 	}
 }
 

--- a/unionfs/unionfs_test_linux.go
+++ b/unionfs/unionfs_test_linux.go
@@ -1,0 +1,44 @@
+// Copyright 2016 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package unionfs
+
+import (
+	"io/ioutil"
+)
+
+func TestUnionFsFdLeak(t *testing.T) {
+	beforeEntries, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	wd, clean := setupUfs(t)
+	err = ioutil.WriteFile(wd+"/ro/file", []byte("blablabla"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	setRecursiveWritable(t, wd+"/ro", false)
+
+	contents, err := ioutil.ReadFile(wd + "/mnt/file")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	err = ioutil.WriteFile(wd+"/mnt/file", contents, 0644)
+	if err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	clean()
+
+	afterEntries, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	if len(afterEntries) != len(beforeEntries) {
+		t.Errorf("/proc/self/fd changed size: after %v before %v", len(beforeEntries), len(afterEntries))
+	}
+}

--- a/unionfs/unionfs_xattr_test_darwin.go
+++ b/unionfs/unionfs_xattr_test_darwin.go
@@ -1,0 +1,37 @@
+// Copyright 2016 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package unionfs
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Darwin doesn't have support for syscall.Getxattr() so we pull it into its own file and implement it by hand on Darwin.
+func Getxattr(path string, attr string, dest []byte) (sz int, err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	var _p1 *byte
+	_p1, err = syscall.BytePtrFromString(attr)
+	if err != nil {
+		return
+	}
+	var _p2 unsafe.Pointer
+	if len(dest) > 0 {
+		_p2 = unsafe.Pointer(&dest[0])
+	} else {
+		var _zero uintptr
+		_p2 = unsafe.Pointer(&_zero)
+	}
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(_p2), uintptr(len(dest)), 0, 0)
+	sz = int(r0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/unionfs/unionfs_xattr_test_linux.go
+++ b/unionfs/unionfs_xattr_test_linux.go
@@ -1,0 +1,14 @@
+// Copyright 2016 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package unionfs
+
+import (
+	"syscall"
+)
+
+// Darwin doesn't have support for syscall.Getxattr() so we pull it into its own file and implement it by hand on Darwin.
+func Getxattr(path string, attr string, dest []byte) (sz int, err error) {
+	return syscall.Getxattr(path, attr, dest)
+}

--- a/zipfs/multizip.go
+++ b/zipfs/multizip.go
@@ -87,6 +87,7 @@ func (fs *MultiZipFs) OpenDir(name string, context *fuse.Context) (stream []fuse
 
 func (fs *MultiZipFs) GetAttr(name string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
 	a := &fuse.Attr{}
+	a.Owner = *fuse.CurrentOwner()
 	if name == "" {
 		// Should not write in top dir.
 		a.Mode = fuse.S_IFDIR | 0500
@@ -137,7 +138,7 @@ func (fs *MultiZipFs) Unlink(name string, context *fuse.Context) (code fuse.Stat
 		delete(fs.zips, basename)
 		delete(fs.dirZipFileMap, basename)
 
-		// Drop lock to ensure that notify doesn't cause deadlock.
+		// Drop the lock to ensure that notify doesn't cause a deadlock.
 		fs.lock.Unlock()
 		code = fs.nodeFs.UnmountNode(root.Inode())
 		fs.lock.Lock()

--- a/zipfs/multizip_test.go
+++ b/zipfs/multizip_test.go
@@ -125,7 +125,7 @@ func TestMultiZipFs(t *testing.T) {
 	}
 
 	// If FUSE supports invalid inode notifications we expect this node to be gone. Otherwise we'll just make sure that it's not reachable.
-	if server.SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
+	if server.KernelSettings().SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
 		fi, err = os.Stat(mountPoint + "/zipmount")
 		if err == nil {
 			t.Errorf("stat should fail after unmount, got %#v", fi)

--- a/zipfs/multizip_test.go
+++ b/zipfs/multizip_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
 	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
@@ -23,7 +24,7 @@ func VerboseTest() bool {
 
 const testTtl = 100 * time.Millisecond
 
-func setupMzfs(t *testing.T) (mountPoint string, cleanup func()) {
+func setupMzfs(t *testing.T) (mountPoint string, state *fuse.Server, cleanup func()) {
 	fs := NewMultiZipFs()
 	mountPoint, _ = ioutil.TempDir("", "")
 	nfs := pathfs.NewPathNodeFs(fs, nil)
@@ -37,15 +38,16 @@ func setupMzfs(t *testing.T) (mountPoint string, cleanup func()) {
 		t.Fatalf("MountNodeFileSystem failed: %v", err)
 	}
 	go state.Serve()
+	state.WaitMount()
 
-	return mountPoint, func() {
+	return mountPoint, state, func() {
 		state.Unmount()
 		os.RemoveAll(mountPoint)
 	}
 }
 
 func TestMultiZipReadonly(t *testing.T) {
-	mountPoint, cleanup := setupMzfs(t)
+	mountPoint, _, cleanup := setupMzfs(t)
 	defer cleanup()
 
 	_, err := os.Create(mountPoint + "/random")
@@ -60,7 +62,7 @@ func TestMultiZipReadonly(t *testing.T) {
 }
 
 func TestMultiZipFs(t *testing.T) {
-	mountPoint, cleanup := setupMzfs(t)
+	mountPoint, server, cleanup := setupMzfs(t)
 	defer cleanup()
 
 	zipFile := testZipFile()
@@ -122,8 +124,22 @@ func TestMultiZipFs(t *testing.T) {
 		t.Fatalf("Remove failed: %v", err)
 	}
 
-	fi, err = os.Stat(mountPoint + "/zipmount")
-	if err == nil {
-		t.Errorf("stat should fail after unmount, got %#v", fi)
+	// Note that FUSE API 7.11 introduced the notification support required to cause the node to be immediately removed. This check will fail in earlier versions.
+	if _, minor := server.Version(); minor >= 11 {
+		fi, err = os.Stat(mountPoint + "/zipmount")
+		if err == nil {
+			t.Errorf("stat should fail after unmount, got %#v", fi)
+		}
+	} else {
+		entries, err = ioutil.ReadDir(mountPoint)
+		if err != nil {
+			t.Fatalf("ReadDir failed: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name() == "zipmount" {
+				t.Error("Should not have entry: ", e)
+			}
+		}
 	}
+
 }

--- a/zipfs/multizip_test.go
+++ b/zipfs/multizip_test.go
@@ -124,8 +124,8 @@ func TestMultiZipFs(t *testing.T) {
 		t.Fatalf("Remove failed: %v", err)
 	}
 
-	// Note that FUSE API 7.11 introduced the notification support required to cause the node to be immediately removed. This check will fail in earlier versions.
-	if _, minor := server.Version(); minor >= 11 {
+	// If FUSE supports invalid inode notifications we expect this node to be gone. Otherwise we'll just make sure that it's not reachable.
+	if server.SupportsNotify(fuse.NOTIFY_INVAL_INODE) {
 		fi, err = os.Stat(mountPoint + "/zipmount")
 		if err == nil {
 			t.Errorf("stat should fail after unmount, got %#v", fi)

--- a/zipfs/zipfs_test.go
+++ b/zipfs/zipfs_test.go
@@ -36,6 +36,7 @@ func setupZipfs(t *testing.T) (mountPoint string, cleanup func()) {
 	})
 
 	go state.Serve()
+	state.WaitMount()
 
 	return mountPoint, func() {
 		state.Unmount()


### PR DESCRIPTION
Everything except for unionfs is now passing. Still chasing down some bugs there, but wanted to see if there was interest before continuing.

Found a legit bug in unionfs:
When the Finder sent it an unexpected getxattr unionfs responded ENOSYS because the subordinate filesystem returned it. Returning ENOSYS causes FUSE to *never* send more getxattrs. We can intercept that and replace it with ENODATA.