### PR TITLE
added Link() to FileSystem

### DIFF
--- a/fuse/pathfs/api.go
+++ b/fuse/pathfs/api.go
@@ -71,7 +71,7 @@ type FileSystem interface {
 	// Symlinks.
 	Symlink(value string, linkName string, context *fuse.Context) (code fuse.Status)
 	Readlink(name string, context *fuse.Context) (string, fuse.Status)
-
+	Link(oldName string, newName string, context *fuse.Context) (code fuse.Status)
 	StatFs(name string) *fuse.StatfsOut
 }
 


### PR DESCRIPTION
Wont build without type FileSystem having a link().  pathfs/locking.go
fails to build because it expects type FileSystem to have method
.link(), so method was added to the interface