### PR TITLE
fix ENOATTR handling for darwin

### DIFF
--- a/fuse/defaultraw.go
+++ b/fuse/defaultraw.go
@@ -86,7 +86,7 @@ func (fs *defaultRawFileSystem) GetXAttrSize(header *InHeader, attr string) (siz
 }
 
 func (fs *defaultRawFileSystem) GetXAttrData(header *InHeader, attr string) (data []byte, code Status) {
-	return nil, ENODATA
+	return nil, ENOATTR
 }
 
 func (fs *defaultRawFileSystem) SetXAttr(input *SetXAttrIn, attr string, data []byte) Status {

--- a/fuse/nodefs/defaultnode.go
+++ b/fuse/nodefs/defaultnode.go
@@ -110,7 +110,7 @@ func (n *defaultNode) OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Stat
 }
 
 func (n *defaultNode) GetXAttr(attribute string, context *fuse.Context) (data []byte, code fuse.Status) {
-	return nil, fuse.ENODATA
+	return nil, fuse.ENOATTR
 }
 
 func (n *defaultNode) RemoveXAttr(attr string, context *fuse.Context) fuse.Status {

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -182,7 +182,7 @@ func doGetXAttr(server *Server, req *request) {
 		fn := req.filenames[0]
 		if fn == _SECURITY_CAPABILITY || fn == _SECURITY_ACL_DEFAULT ||
 			fn == _SECURITY_ACL {
-			req.status = ENODATA
+			req.status = ENOATTR
 			return
 		}
 	}

--- a/fuse/pathfs/default.go
+++ b/fuse/pathfs/default.go
@@ -28,7 +28,7 @@ func (fs *defaultFileSystem) GetAttr(name string, context *fuse.Context) (*fuse.
 }
 
 func (fs *defaultFileSystem) GetXAttr(name string, attr string, context *fuse.Context) ([]byte, fuse.Status) {
-	return nil, fuse.ENOSYS
+	return nil, fuse.ENOATTR
 }
 
 func (fs *defaultFileSystem) SetXAttr(name string, attr string, data []byte, flags int, context *fuse.Context) fuse.Status {

--- a/fuse/pathfs/xattr_test.go
+++ b/fuse/pathfs/xattr_test.go
@@ -72,7 +72,7 @@ func (fs *XAttrTestFs) GetXAttr(name string, attr string, context *fuse.Context)
 	}
 	v, ok := fs.attrs[attr]
 	if !ok {
-		return nil, fuse.ENODATA
+		return nil, fuse.ENOATTR
 	}
 	return v, fuse.OK
 }
@@ -94,7 +94,7 @@ func (fs *XAttrTestFs) RemoveXAttr(name string, attr string, context *fuse.Conte
 	}
 	_, ok := fs.attrs[attr]
 	if !ok {
-		return fuse.ENODATA
+		return fuse.ENOATTR
 	}
 	delete(fs.attrs, attr)
 	return fuse.OK
@@ -200,7 +200,7 @@ func TestXAttrRead(t *testing.T) {
 
 	sysRemovexattr(mounted, "third")
 	val, err = readXAttr(mounted, "third")
-	if err != syscall.ENODATA {
+	if err != syscall.ENOATTR {
 		t.Error("Data not removed?", err, val)
 	}
 }

--- a/fuse/test/fsetattr_test.go
+++ b/fuse/test/fsetattr_test.go
@@ -105,7 +105,7 @@ type FSetAttrFs struct {
 }
 
 func (fs *FSetAttrFs) GetXAttr(name string, attr string, context *fuse.Context) ([]byte, fuse.Status) {
-	return nil, fuse.ENODATA
+	return nil, fuse.ENOATTR
 }
 
 func (fs *FSetAttrFs) GetAttr(name string, context *fuse.Context) (*fuse.Attr, fuse.Status) {

--- a/fuse/types_darwin.go
+++ b/fuse/types_darwin.go
@@ -4,6 +4,14 @@
 
 package fuse
 
+import (
+	"syscall"
+)
+
+const (
+	ENOATTR = Status(syscall.ENOATTR) // ENOATTR is not defined for all GOOS.
+)
+
 type Attr struct {
 	Ino         uint64
 	Size        uint64

--- a/fuse/types_linux.go
+++ b/fuse/types_linux.go
@@ -4,6 +4,14 @@
 
 package fuse
 
+import (
+	"syscall"
+)
+
+const (
+	ENOATTR = Status(syscall.ENODATA) // On Linux, ENOATTR is an alias for ENODATA.
+)
+
 type Attr struct {
 	Ino       uint64
 	Size      uint64

--- a/unionfs/autounion.go
+++ b/unionfs/autounion.go
@@ -297,7 +297,7 @@ func (fs *autoUnionFs) Unlink(path string, context *fuse.Context) (code fuse.Sta
 
 // Must define this, because ENOSYS will suspend all GetXAttr calls.
 func (fs *autoUnionFs) GetXAttr(name string, attr string, context *fuse.Context) ([]byte, fuse.Status) {
-	return nil, fuse.ENODATA
+	return nil, fuse.ENOATTR
 }
 
 func (fs *autoUnionFs) GetAttr(path string, context *fuse.Context) (*fuse.Attr, fuse.Status) {

--- a/unionfs/unionfs.go
+++ b/unionfs/unionfs.go
@@ -708,7 +708,7 @@ func (fs *unionFS) GetAttr(name string, context *fuse.Context) (a *fuse.Attr, s 
 
 func (fs *unionFS) GetXAttr(name string, attr string, context *fuse.Context) ([]byte, fuse.Status) {
 	if name == _DROP_CACHE {
-		return nil, fuse.ENODATA
+		return nil, fuse.ENOATTR
 	}
 	r := fs.getBranch(name)
 	if r.branch >= 0 {

--- a/unionfs/unionfs_xattr_test.go
+++ b/unionfs/unionfs_xattr_test.go
@@ -36,7 +36,7 @@ func (fs *TestFS) GetXAttr(path string, name string, context *fuse.Context) ([]b
 		fs.xattrRead++
 		return []byte{42}, fuse.OK
 	}
-	return nil, fuse.ENODATA
+	return nil, fuse.ENOATTR
 }
 
 func TestXAttrCaching(t *testing.T) {


### PR DESCRIPTION
On Mac OS X the Finder loses its mind if GetXAttr returns ENODATA rather than ENOATTR. On Linux, ENOATTR is just an alias for ENOATTR.

Note that the Linux man page references ENOATTR:
http://man7.org/linux/man-pages/man2/fgetxattr.2.html

You can also see the discussion regarding the golang syscall package:
https://github.com/golang/go/issues/753

Both discussion note that ENOATTR is a synonym for ENODATA.

On Mac OS X, that's not the case:

```
...
#if __DARWIN_C_LEVEL >= __DARWIN_C_FULL
#define ENOATTR         93              /* Attribute not found */
#endif

#define EBADMSG         94              /* Bad message */
#define EMULTIHOP       95              /* Reserved */
#define ENODATA         96              /* No message available on STREAM */
...
```

Note that we could take the approach of removing ENODATA altogether, but I worry that that would break existing users. Unfortunately Go doesn't seem to have a mechanism to deprecate an interface.

Still another approach would be to translate ENODATA to ENOATTR on darwin (since they're actually different codes), but that seems like a kludge.