### PR TITLE
loopback: re-enable nanoseconds for dates after 1970

### DIFF
--- a/fuse/nodefs/files_linux.go
+++ b/fuse/nodefs/files_linux.go
@@ -24,24 +24,30 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 const _UTIME_NOW = ((1 << 30) - 1)
 const _UTIME_OMIT = ((1 << 30) - 2)
 
+// utimeToTimespec converts a "time.Time" pointer as passed to Utimens to a
+// Timespec that can be passed to the utimensat syscall.
+//
+// Note: pathfs and nodefs both have a copy of this function, so make sure
+// to update both.
+func utimeToTimespec(t *time.Time) (ts syscall.Timespec) {
+	if t == nil {
+		ts.Nsec = _UTIME_OMIT
+	} else {
+		ts = syscall.NsecToTimespec(t.UnixNano())
+		// For dates before 1970, NsecToTimespec incorrectly returns negative
+		// nanoseconds. Ticket: https://github.com/golang/go/issues/12777
+		if ts.Nsec < 0 {
+			ts.Nsec = 0
+		}
+	}
+	return ts
+}
+
 // Utimens - file handle based version of loopbackFileSystem.Utimens()
 func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
 	var ts [2]syscall.Timespec
-
-	if a == nil {
-		ts[0].Nsec = _UTIME_OMIT
-	} else {
-		ts[0] = syscall.NsecToTimespec(a.UnixNano())
-		ts[0].Nsec = 0
-	}
-
-	if m == nil {
-		ts[1].Nsec = _UTIME_OMIT
-	} else {
-		ts[1] = syscall.NsecToTimespec(a.UnixNano())
-		ts[1].Nsec = 0
-	}
-
+	ts[0] = utimeToTimespec(a)
+	ts[1] = utimeToTimespec(m)
 	f.lock.Lock()
 	err := futimens(int(f.File.Fd()), &ts)
 	f.lock.Unlock()

--- a/fuse/pathfs/loopback_linux.go
+++ b/fuse/pathfs/loopback_linux.go
@@ -60,24 +60,30 @@ func (fs *loopbackFileSystem) SetXAttr(name string, attr string, data []byte, fl
 const _UTIME_NOW = ((1 << 30) - 1)
 const _UTIME_OMIT = ((1 << 30) - 2)
 
+// utimeToTimespec converts a "time.Time" pointer as passed to Utimens to a
+// Timespec that can be passed to the utimensat syscall.
+//
+// Note: pathfs and nodefs both have a copy of this function, so make sure
+// to update both.
+func utimeToTimespec(t *time.Time) (ts syscall.Timespec) {
+	if t == nil {
+		ts.Nsec = _UTIME_OMIT
+	} else {
+		ts = syscall.NsecToTimespec(t.UnixNano())
+		// For dates before 1970, NsecToTimespec incorrectly returns negative
+		// nanoseconds. Ticket: https://github.com/golang/go/issues/12777
+		if ts.Nsec < 0 {
+			ts.Nsec = 0
+		}
+	}
+	return ts
+}
+
 // Utimens - path based version of loopbackFile.Utimens()
 func (fs *loopbackFileSystem) Utimens(path string, a *time.Time, m *time.Time, context *fuse.Context) (code fuse.Status) {
 	var ts [2]syscall.Timespec
-
-	if a == nil {
-		ts[0].Nsec = _UTIME_OMIT
-	} else {
-		ts[0] = syscall.NsecToTimespec(a.UnixNano())
-		ts[0].Nsec = 0
-	}
-
-	if m == nil {
-		ts[1].Nsec = _UTIME_OMIT
-	} else {
-		ts[1] = syscall.NsecToTimespec(m.UnixNano())
-		ts[1].Nsec = 0
-	}
-
+	ts[0] = utimeToTimespec(a)
+	ts[1] = utimeToTimespec(m)
 	err := sysUtimensat(0, fs.GetPath(path), &ts, _AT_SYMLINK_NOFOLLOW)
 	return fuse.ToStatus(err)
 }


### PR DESCRIPTION
For dates before 1970, syscall.NsecToTimespec() incorrectly
returns negative nanoseconds.
Ticket: https://github.com/golang/go/issues/12777

Handle that case by zeroing out Nsec if it is negative,
but otherwise keep the value.

This makes nanoseconds work for the vast majority of use
cases.