### PR TITLE
loopback: Utimens: enable Nsec precision for dates after 1970

### DIFF
--- a/fuse/misc.go
+++ b/fuse/misc.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"syscall"
+	"time"
 	"unsafe"
 )
 
@@ -85,4 +86,22 @@ func init() {
 	if p != PAGESIZE {
 		log.Panicf("page size incorrect: %d", p)
 	}
+}
+
+const _UTIME_OMIT = ((1 << 30) - 2)
+
+// UtimeToTimespec converts a "Time" pointer as passed to Utimens to a
+// "Timespec" that can be passed to the utimensat syscall.
+// A nil pointer is converted to the special UTIME_OMIT value.
+func UtimeToTimespec(t *time.Time) (ts syscall.Timespec) {
+	if t == nil {
+		ts.Nsec = _UTIME_OMIT
+	} else {
+		ts = syscall.NsecToTimespec(t.UnixNano())
+		// Go bug https://github.com/golang/go/issues/12777
+		if ts.Nsec < 0 {
+			ts.Nsec = 0
+		}
+	}
+	return ts
 }

--- a/fuse/nodefs/files_darwin.go
+++ b/fuse/nodefs/files_darwin.go
@@ -65,7 +65,6 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 	return fuse.OK
 }
 
-const _UTIME_NOW = ((1 << 30) - 1)
 const _UTIME_OMIT = ((1 << 30) - 2)
 
 // timeToTimeval - Convert time.Time to syscall.Timeval

--- a/fuse/nodefs/files_linux.go
+++ b/fuse/nodefs/files_linux.go
@@ -21,27 +21,11 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 	return fuse.OK
 }
 
-const _UTIME_NOW = ((1 << 30) - 1)
-const _UTIME_OMIT = ((1 << 30) - 2)
-
 // Utimens - file handle based version of loopbackFileSystem.Utimens()
 func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
 	var ts [2]syscall.Timespec
-
-	if a == nil {
-		ts[0].Nsec = _UTIME_OMIT
-	} else {
-		ts[0] = syscall.NsecToTimespec(a.UnixNano())
-		ts[0].Nsec = 0
-	}
-
-	if m == nil {
-		ts[1].Nsec = _UTIME_OMIT
-	} else {
-		ts[1] = syscall.NsecToTimespec(a.UnixNano())
-		ts[1].Nsec = 0
-	}
-
+	ts[0] = fuse.UtimeToTimespec(a)
+	ts[1] = fuse.UtimeToTimespec(m)
 	f.lock.Lock()
 	err := futimens(int(f.File.Fd()), &ts)
 	f.lock.Unlock()

--- a/fuse/pathfs/loopback_linux.go
+++ b/fuse/pathfs/loopback_linux.go
@@ -39,27 +39,11 @@ func (fs *loopbackFileSystem) SetXAttr(name string, attr string, data []byte, fl
 	return fuse.ToStatus(err)
 }
 
-const _UTIME_NOW = ((1 << 30) - 1)
-const _UTIME_OMIT = ((1 << 30) - 2)
-
 // Utimens - path based version of loopbackFile.Utimens()
 func (fs *loopbackFileSystem) Utimens(path string, a *time.Time, m *time.Time, context *fuse.Context) (code fuse.Status) {
 	var ts [2]syscall.Timespec
-
-	if a == nil {
-		ts[0].Nsec = _UTIME_OMIT
-	} else {
-		ts[0] = syscall.NsecToTimespec(a.UnixNano())
-		ts[0].Nsec = 0
-	}
-
-	if m == nil {
-		ts[1].Nsec = _UTIME_OMIT
-	} else {
-		ts[1] = syscall.NsecToTimespec(m.UnixNano())
-		ts[1].Nsec = 0
-	}
-
+	ts[0] = fuse.UtimeToTimespec(a)
+	ts[1] = fuse.UtimeToTimespec(m)
 	err := sysUtimensat(0, fs.GetPath(path), &ts, _AT_SYMLINK_NOFOLLOW)
 	return fuse.ToStatus(err)
 }


### PR DESCRIPTION
syscall.NsecToTimespec is broken for dates before 1970 but works
fine otherwise.

Fix #100 as well and add a testcase.