### PR TITLE
Loopback: Making the code for Read() consistent with the code for Write()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+sudo: required
+dist: trusty
+before_install:
+  - sudo apt-get install -qq fuse
+  - sudo modprobe fuse
+  - sudo /bin/sh -c 'echo user_allow_other > /etc/fuse.conf'
+  - sudo chmod 666 /dev/fuse
+  - sudo chown root:$USER /etc/fuse.conf
+script:
+  - go get -t -v ./...
+  - go test -v ./...


### PR DESCRIPTION
In issue #132, I was wondering why the read buffer was not filled in the Read() function. Now that I understand better what is going on, I would like to suggest this patch, which IMHO makes the code more understandable.

I think this version is simpler for the newcomer, because one can see how the result is filled directly from the Read() function, rather than having to dive in the code of readResultFd.

Feel free to take the patch, unless you believe this does not improve the readability.