### PR TITLE
fix first unionfs test datarace

### DIFF
--- a/unionfs/unionfs_xattr_test.go
+++ b/unionfs/unionfs_xattr_test.go
@@ -6,6 +6,7 @@ package unionfs
 
 import (
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 type TestFS struct {
 	pathfs.FileSystem
-	xattrRead int
+	xattrRead int64
 }
 
 func (fs *TestFS) GetAttr(path string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
@@ -32,7 +33,7 @@ func (fs *TestFS) GetAttr(path string, context *fuse.Context) (*fuse.Attr, fuse.
 
 func (fs *TestFS) GetXAttr(path string, name string, context *fuse.Context) ([]byte, fuse.Status) {
 	if path == "file" && name == "user.attr" {
-		fs.xattrRead++
+		atomic.AddInt64(&fs.xattrRead, 1)
 		return []byte{42}, fuse.OK
 	}
 	return nil, fuse.ENOATTR
@@ -116,8 +117,8 @@ func TestXAttrCaching(t *testing.T) {
 	if got != want {
 		t.Fatalf("Got %q want %q", got, err)
 	}
-
-	if roFS.xattrRead != 1 {
-		t.Errorf("got xattrRead=%d, want 1", roFS.xattrRead)
+	actual := atomic.LoadInt64(&roFS.xattrRead)
+	if actual != 1 {
+		t.Errorf("got xattrRead=%d, want 1", actual)
 	}
 }


### PR DESCRIPTION
This first race was easy to find and fix in the tests themselves.

It exposes another race in nodefs.FileSystemConnector where a node's
mount (and therefore, treeLock) is is not the same as the grand-parent
node's is.

Updates #138.