### PR TITLE
nodefs: fix data race in Inode.Parent()

### DIFF
--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -94,6 +94,8 @@ func (n *Inode) Parent() (parent *Inode, name string) {
 	if n.mountPoint != nil {
 		return nil, ""
 	}
+	n.mount.treeLock.RLock()
+	defer n.mount.treeLock.RUnlock()
 	for k := range n.parents {
 		return k.parent, k.name
 	}


### PR DESCRIPTION
We have to take the treeLock before looking
at the parents map.

However, adding the lock here shows deadlocks when testing with
fsstress (backtrace below [1]).

Dropping pathLock from pathInode.GetPath fixes the deadlocks.
The lock does not seem to  protect anything and fsstress testing runs
fine without it.

Fixes the data race reported at https://github.com/hanwen/go-fuse/issues/166 .

[1] Appendix:
```
goroutine 11 [semacquire]:
[...]
sync.(*Mutex).Lock(0xc4200ee6d8)
	/usr/local/go/src/sync/mutex.go:87 +0x9d
github.com/hanwen/go-fuse/fuse/nodefs.(*FileSystemConnector).forgetUpdate(0xc42001dc80, 0x29, 0x1)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/fsconnector.go:137 +0xad
github.com/hanwen/go-fuse/fuse/nodefs.(*rawBridge).Forget(0xc42001dc80, 0x29, 0x1)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/fsops.go:128 +0x3f
github.com/hanwen/go-fuse/fuse.doBatchForget(0xc4200921c0, 0xc4200d86c0)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/opcode.go:275 +0x10a
[...]

goroutine 13 [semacquire]:
[...]
sync.(*RWMutex).Lock(0xc420088c08)
	/usr/local/go/src/sync/rwmutex.go:91 +0x6e
github.com/hanwen/go-fuse/fuse/pathfs.(*pathInode).OnRemove(0xc42028f0e0, 0xc42042e460, 0xc42015f680, 0x12)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/pathfs/pathfs.go:341 +0x63
github.com/hanwen/go-fuse/fuse/nodefs.(*Inode).rmChild(0xc42042e460, 0xc42015f680, 0x12, 0xc42004be68)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/inode.go:218 +0x18f
github.com/hanwen/go-fuse/fuse/nodefs.(*FileSystemConnector).forgetUpdate(0xc42001dc80, 0x11, 0x1)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/fsconnector.go:157 +0x345
github.com/hanwen/go-fuse/fuse/nodefs.(*rawBridge).Forget(0xc42001dc80, 0x11, 0x1)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/fsops.go:128 +0x3f
github.com/hanwen/go-fuse/fuse.doForget(0xc4200921c0, 0xc42025e000)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/opcode.go:250 +0x69
[...]

goroutine 26 [semacquire]:
[...]
sync.(*Mutex).Lock(0xc4200ee6d8)
	/usr/local/go/src/sync/mutex.go:87 +0x9d
github.com/hanwen/go-fuse/fuse/nodefs.(*Inode).Parent(0xc4202aa2a0, 0x0, 0x0, 0x0)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/inode.go:97 +0x7c
github.com/hanwen/go-fuse/fuse/pathfs.(*pathInode).GetPath(0xc42028e5d0, 0xc420051e28, 0x5c43d6)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/pathfs/pathfs.go:285 +0xc5
github.com/hanwen/go-fuse/fuse/pathfs.(*pathInode).Rmdir(0xc42028e5d0, 0xc4203cd730, 0x3, 0xc42025e620, 0xc420051eb8)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/pathfs/pathfs.go:448 +0x2f
github.com/hanwen/go-fuse/fuse/nodefs.(*rawBridge).Rmdir(0xc42001dc80, 0xc42025e608, 0xc4203cd730, 0x3, 0x680be8)
	/home/jakob/go/src/github.com/hanwen/go-fuse/fuse/nodefs/fsops.go:309 +0x77
[...]
```