### PR TITLE
nodefs: fix data race in Inode.Parent()

### DIFF
--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -94,6 +94,8 @@ func (n *Inode) Parent() (parent *Inode, name string) {
 	if n.mountPoint != nil {
 		return nil, ""
 	}
+	n.mount.treeLock.RLock()
+	defer n.mount.treeLock.RUnlock()
 	for k := range n.parents {
 		return k.parent, k.name
 	}


### PR DESCRIPTION
Inode.Parent() has to take the treeLock before looking
at the parents map.

Fixes https://github.com/hanwen/go-fuse/issues/166