### PR TITLE
Close the fuse file descriptor on exec

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -70,6 +70,11 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 		return -1, err
 	}
 
+	// golang sets CLOEXEC on file descriptors when they are
+	// acquired through normal operations (e.g. open).
+	// Buf for fd, we have to set CLOEXEC manually
+	syscall.CloseOnExec(fd)
+
 	close(ready)
 	return fd, err
 }

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -406,7 +406,7 @@ func (ms *Server) handleRequest(req *request) Status {
 	}
 
 	errNo := ms.write(req)
-	if errNo != 0 {
+	if errNo != OK {
 		log.Printf("writer: Write/Writev failed, err: %v. opcode: %v",
 			errNo, operationName(req.inHeader.Opcode))
 	}


### PR DESCRIPTION
When a process forks and execs a new process, the child will not be interested in the parent's file descriptor to /dev/fuse.