### PR TITLE
Add support for d_ino

### DIFF
--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	var finalFs pathfs.FileSystem
 	orig := flag.Arg(1)
-	loopbackfs := pathfs.NewLoopbackFileSystem(orig)
+	loopbackfs := pathfs.NewLoopbackInoFileSystem(orig)
 	finalFs = loopbackfs
 
 	opts := &nodefs.Options{

--- a/fuse/nodefs/api.go
+++ b/fuse/nodefs/api.go
@@ -93,6 +93,7 @@ type Node interface {
 	// directly.
 	Open(flags uint32, context *fuse.Context) (file File, code fuse.Status)
 	OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Status)
+	OpenDirIno(context *fuse.Context) ([]fuse.DirEntryIno, fuse.Status)
 	Read(file File, dest []byte, off int64, context *fuse.Context) (fuse.ReadResult, fuse.Status)
 	Write(file File, data []byte, off int64, context *fuse.Context) (written uint32, code fuse.Status)
 

--- a/fuse/nodefs/api.go
+++ b/fuse/nodefs/api.go
@@ -93,6 +93,7 @@ type Node interface {
 	// directly.
 	Open(flags uint32, context *fuse.Context) (file File, code fuse.Status)
 	OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Status)
+	// OpenDirIno is only called if OpenDir returns fuse.ENOSYS.
 	OpenDirIno(context *fuse.Context) ([]fuse.DirEntryIno, fuse.Status)
 	Read(file File, dest []byte, off int64, context *fuse.Context) (fuse.ReadResult, fuse.Status)
 	Write(file File, data []byte, off int64, context *fuse.Context) (written uint32, code fuse.Status)

--- a/fuse/nodefs/defaultnode.go
+++ b/fuse/nodefs/defaultnode.go
@@ -109,6 +109,10 @@ func (n *defaultNode) OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Stat
 	return s, fuse.OK
 }
 
+func (n *defaultNode) OpenDirIno(context *fuse.Context) ([]fuse.DirEntryIno, fuse.Status) {
+	return nil, fuse.ENOSYS
+}
+
 func (n *defaultNode) GetXAttr(attribute string, context *fuse.Context) (data []byte, code fuse.Status) {
 	return nil, fuse.ENOATTR
 }

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -156,7 +156,7 @@ func (c *rawBridge) GetAttr(input *fuse.GetAttrIn, out *fuse.AttrOut) (code fuse
 
 func (c *rawBridge) OpenDir(input *fuse.OpenIn, out *fuse.OpenOut) (code fuse.Status) {
 	node := c.toInode(input.NodeId)
-	stream, err := node.fsInode.OpenDir(&input.Context)
+	stream, err := openDirIno(node.fsInode, &input.Context)
 	if err != fuse.OK {
 		return err
 	}
@@ -164,8 +164,8 @@ func (c *rawBridge) OpenDir(input *fuse.OpenIn, out *fuse.OpenOut) (code fuse.St
 	de := &connectorDir{
 		node: node.Node(),
 		stream: append(stream,
-			fuse.DirEntry{Mode: fuse.S_IFDIR, Name: "."},
-			fuse.DirEntry{Mode: fuse.S_IFDIR, Name: ".."}),
+			fuse.DirEntryIno{fuse.S_IFDIR, ".", fuse.FUSE_UNKNOWN_INO},
+			fuse.DirEntryIno{fuse.S_IFDIR, "..", fuse.FUSE_UNKNOWN_INO}),
 		rawFS: c,
 	}
 	h, opened := node.mount.registerFileHandle(node, de, nil, input.Flags)

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -250,13 +250,14 @@ func (n *Inode) canUnmount() bool {
 	return ok
 }
 
-func (n *Inode) getMountDirEntries() (out []fuse.DirEntry) {
+func (n *Inode) getMountDirEntries() (out []fuse.DirEntryIno) {
 	n.mount.treeLock.RLock()
 	for k, v := range n.children {
 		if v.mountPoint != nil {
-			out = append(out, fuse.DirEntry{
+			out = append(out, fuse.DirEntryIno{
 				Name: k,
 				Mode: fuse.S_IFDIR,
+				Ino:  fuse.FUSE_UNKNOWN_INO,
 			})
 		}
 	}

--- a/fuse/pathfs/api.go
+++ b/fuse/pathfs/api.go
@@ -67,6 +67,8 @@ type FileSystem interface {
 
 	// Directory handling
 	OpenDir(name string, context *fuse.Context) (stream []fuse.DirEntry, code fuse.Status)
+	// OpenDirIno is only called if OpenDir returns fuse.ENOSYS.
+	OpenDirIno(name string, context *fuse.Context) (stream []fuse.DirEntryIno, code fuse.Status)
 
 	// Symlinks.
 	Symlink(value string, linkName string, context *fuse.Context) (code fuse.Status)

--- a/fuse/pathfs/default.go
+++ b/fuse/pathfs/default.go
@@ -95,6 +95,10 @@ func (fs *defaultFileSystem) OpenDir(name string, context *fuse.Context) (stream
 	return nil, fuse.ENOSYS
 }
 
+func (fs *defaultFileSystem) OpenDirIno(name string, context *fuse.Context) (stream []fuse.DirEntryIno, status fuse.Status) {
+	return nil, fuse.ENOSYS
+}
+
 func (fs *defaultFileSystem) OnMount(nodeFs *PathNodeFs) {
 }
 

--- a/fuse/pathfs/locking.go
+++ b/fuse/pathfs/locking.go
@@ -118,6 +118,11 @@ func (fs *lockingFileSystem) OpenDir(name string, context *fuse.Context) (stream
 	return fs.FS.OpenDir(name, context)
 }
 
+func (fs *lockingFileSystem) OpenDirIno(name string, context *fuse.Context) (stream []fuse.DirEntryIno, status fuse.Status) {
+	defer fs.locked()()
+	return fs.FS.OpenDirIno(name, context)
+}
+
 func (fs *lockingFileSystem) OnMount(nodeFs *PathNodeFs) {
 	defer fs.locked()()
 	fs.FS.OnMount(nodeFs)

--- a/fuse/pathfs/loopbackino.go
+++ b/fuse/pathfs/loopbackino.go
@@ -1,0 +1,24 @@
+// Copyright 2016 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pathfs
+
+import (
+	"github.com/hanwen/go-fuse/fuse"
+)
+
+type loopbackInoFileSystem struct {
+	loopbackFileSystem
+}
+
+// NewLoopbackInoFileSystem is like NewLoopbackFileSystem but uses OpenDirIno
+// instead of OpenDir.
+func NewLoopbackInoFileSystem(root string) FileSystem {
+	fs := NewLoopbackFileSystem(root).(*loopbackFileSystem)
+	return &loopbackInoFileSystem{*fs}
+}
+
+func (fs *loopbackInoFileSystem) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
+	return nil, fuse.ENOSYS
+}

--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -412,6 +412,10 @@ func (n *pathInode) OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Status
 	return n.fs.OpenDir(n.GetPath(), context)
 }
 
+func (n *pathInode) OpenDirIno(context *fuse.Context) ([]fuse.DirEntryIno, fuse.Status) {
+	return n.fs.OpenDirIno(n.GetPath(), context)
+}
+
 func (n *pathInode) Mknod(name string, mode uint32, dev uint32, context *fuse.Context) (*nodefs.Inode, fuse.Status) {
 	fullPath := filepath.Join(n.GetPath(), name)
 	code := n.fs.Mknod(fullPath, mode, dev, context)

--- a/fuse/pathfs/prefixfs.go
+++ b/fuse/pathfs/prefixfs.go
@@ -87,6 +87,10 @@ func (fs *prefixFileSystem) OpenDir(name string, context *fuse.Context) (stream 
 	return fs.FileSystem.OpenDir(fs.prefixed(name), context)
 }
 
+func (fs *prefixFileSystem) OpenDirIno(name string, context *fuse.Context) (stream []fuse.DirEntryIno, status fuse.Status) {
+	return fs.FileSystem.OpenDirIno(fs.prefixed(name), context)
+}
+
 func (fs *prefixFileSystem) OnMount(nodeFs *PathNodeFs) {
 	fs.FileSystem.OnMount(nodeFs)
 }

--- a/fuse/test/loopback_test.go
+++ b/fuse/test/loopback_test.go
@@ -63,7 +63,7 @@ func (tc *testCase) WriteFile(name string, content []byte, mode os.FileMode) {
 	}
 }
 
-// Create and mount filesystem.
+// Create and mount loopback filesystem.
 func NewTestCase(t *testing.T) *testCase {
 	tc := &testCase{}
 	tc.tester = t
@@ -88,7 +88,7 @@ func NewTestCase(t *testing.T) *testCase {
 	tc.origSubdir = filepath.Join(tc.orig, subdir)
 
 	var pfs pathfs.FileSystem
-	pfs = pathfs.NewLoopbackFileSystem(tc.orig)
+	pfs = pathfs.NewLoopbackInoFileSystem(tc.orig)
 	pfs = pathfs.NewLockingFileSystem(pfs)
 
 	tc.pathFs = pathfs.NewPathNodeFs(pfs, &pathfs.PathNodeFsOptions{


### PR DESCRIPTION
Fixes https://github.com/hanwen/go-fuse/issues/175 while hopefully causing little breakage for apps that use go-fuse. As long as they embed `NewDefaultNode` (nodefs) / `NewDefaultFileSystem` (pathfs) apps should see no change in behavoir.

The patch series passes the go-fuse test suite ([most of the time](https://github.com/hanwen/go-fuse/issues/96), anyway) and the unmodified gocryptfs test suite.