### PR TITLE
fuse, loopback: return actual inode numbers from READDIR

### DIFF
--- a/fuse/pathfs/loopback.go
+++ b/fuse/pathfs/loopback.go
@@ -89,7 +89,7 @@ func (fs *loopbackFileSystem) OpenDir(name string, context *fuse.Context) (strea
 	for {
 		infos, err := f.Readdir(want)
 		for i := range infos {
-			// workaround forhttps://code.google.com/p/go/issues/detail?id=5960
+			// workaround for https://code.google.com/p/go/issues/detail?id=5960
 			if infos[i] == nil {
 				continue
 			}
@@ -99,6 +99,7 @@ func (fs *loopbackFileSystem) OpenDir(name string, context *fuse.Context) (strea
 			}
 			if s := fuse.ToStatT(infos[i]); s != nil {
 				d.Mode = uint32(s.Mode)
+				d.Ino = s.Ino
 			} else {
 				log.Printf("ReadDir entry %q for %q has no stat info", n, name)
 			}

--- a/fuse/test/loopback_linux_test.go
+++ b/fuse/test/loopback_linux_test.go
@@ -5,11 +5,14 @@
 package test
 
 import (
+	"encoding/binary"
 	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func TestTouch(t *testing.T) {
@@ -155,5 +158,36 @@ func TestSpecialEntries(t *testing.T) {
 	n, err := syscall.Getdents(int(d.Fd()), buf)
 	if n == 0 {
 		t.Errorf("directory is empty, entries '.' and '..' are missing")
+	}
+}
+
+// Check that readdir(3) returns valid inode numbers in the directory entries
+func TestReaddirInodes(t *testing.T) {
+	tc := NewTestCase(t)
+	defer tc.Cleanup()
+	// create hello.txt
+	path := tc.origFile
+	err := ioutil.WriteFile(path, []byte("xyz"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// open mountpoint dir
+	d, err := os.Open(tc.mnt)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer d.Close()
+	buf := make([]byte, 100)
+	// readdir(3) use getdents64(2) internally which returns linux_dirent64
+	// structures. We don't have readdir(3) so we call getdents64(2) directly.
+	n, err := syscall.Getdents(int(d.Fd()), buf)
+	if n == 0 {
+		t.Error("empty directory - we need at least one file")
+	}
+	// The inode number of the first directory entry (=hello.txt)
+	// is in the first 8 bytes of the buffer
+	inode := binary.LittleEndian.Uint64(buf)
+	if inode == 0 || inode == fuse.FUSE_UNKNOWN_INO {
+		t.Errorf("got invalid inode number: %d = 0x%x", inode, inode)
 	}
 }


### PR DESCRIPTION
Supersedes https://github.com/hanwen/go-fuse/pull/177. Passes both go-fuse's `all.bash` and gocryptfs' `test.bash` (unmodified). Single commit message follows:

--------------------------

When an app in a FUSE mount calls getdents(2), go-fuse receives
READDIR[PLUS] and calls the filesystem's OpenDir function that
returns []DirEntry.

The data returned from getdents(2) contains an inode number for
each directory entry, "d_ino". Until now, struct DirEntry had no
corresponding field and the value passed to the kernel was always
FUSE_UNKNOWN_INO = 0xffffffff

This broke apps that actually look at the d_ino field, like
"find -inum".

This commit adds the "Ino" filed to struct DirEntry. If the field
is not set by the filesystem, it is set to FUSE_UNKNOWN_INO,
as before. Otherwise it is left alone and passed to the kernel.

loopbackFileSystem's OpenDir function is extended to set the inode
number. A test verifies that the returned inode number is sane.

Fixes https://github.com/hanwen/go-fuse/issues/175