### PR TITLE
fuse, loopback: return actual inode numbers from READDIR

### DIFF
--- a/fuse/pathfs/loopback.go
+++ b/fuse/pathfs/loopback.go
@@ -89,7 +89,7 @@ func (fs *loopbackFileSystem) OpenDir(name string, context *fuse.Context) (strea
 	for {
 		infos, err := f.Readdir(want)
 		for i := range infos {
-			// workaround forhttps://code.google.com/p/go/issues/detail?id=5960
+			// workaround for https://code.google.com/p/go/issues/detail?id=5960
 			if infos[i] == nil {
 				continue
 			}
@@ -99,6 +99,7 @@ func (fs *loopbackFileSystem) OpenDir(name string, context *fuse.Context) (strea
 			}
 			if s := fuse.ToStatT(infos[i]); s != nil {
 				d.Mode = uint32(s.Mode)
+				d.Ino = s.Ino
 			} else {
 				log.Printf("ReadDir entry %q for %q has no stat info", n, name)
 			}


### PR DESCRIPTION
When an app in a FUSE mount calls getdents(2), go-fuse receives
READDIR[PLUS] and calls the filesystem's OpenDir function that
returns []DirEntry.

The data returned from getdents(2) contains an inode number for
each directory entry, "d_ino". Until now, struct DirEntry had no
corresponding field and the value passed to the kernel was always
FUSE_UNKNOWN_INO = 0xffffffff

This broke apps that actually look at the d_ino field, like
"find -inum".

This commit adds the "Ino" filed to struct DirEntry. If the field
is not set by the filesystem, it is set to FUSE_UNKNOWN_INO,
as before. Otherwise it is left alone and passed to the kernel.

loopbackFileSystem's OpenDir function is extended to set the inode
number. A test verifies that the returned inode number is sane.

Fixes https://github.com/hanwen/go-fuse/issues/175