### PR TITLE
nodefs: drop unused fields from Inode struct

### DIFF
--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -35,7 +35,6 @@ type handleMap interface {
 }
 
 type handled struct {
-	check  uint32
 	handle uint64
 	count  int
 }
@@ -77,10 +76,6 @@ func newPortableHandleMap() *portableHandleMap {
 func (m *portableHandleMap) Register(obj *handled) (handle, generation uint64) {
 	m.Lock()
 	if obj.count == 0 {
-		if obj.check != 0 {
-			panic(_ALREADY_MSG)
-		}
-
 		if len(m.freeIds) == 0 {
 			handle = uint64(len(m.handles))
 			m.handles = append(m.handles, obj)

--- a/fuse/nodefs/handle_test.go
+++ b/fuse/nodefs/handle_test.go
@@ -90,9 +90,6 @@ func TestHandleMapBasic(t *testing.T) {
 	if hm.Has(h) {
 		t.Fatal("Still has handle")
 	}
-	if v.check != 0 {
-		t.Errorf("forgotten object still has a check.")
-	}
 }
 
 func TestHandleMapMultiple(t *testing.T) {

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -24,10 +24,6 @@ type parentData struct {
 type Inode struct {
 	handled handled
 
-	// Generation number of the inode. Each (re)use of an inode
-	// should have a unique generation number.
-	generation uint64
-
 	// Number of open files and its protection.
 	openFilesMutex sync.Mutex
 	openFiles      []*openedFile


### PR DESCRIPTION
Reduces Sizeof(nodefs.Inode{}) from 112 to 96 bytes.

The "generation" field in "Inode" is not used anywhere.
"portableHandleMap" has it's own generation field, which
is actually used.

The "check" field, embedded through the "handled" struct,
is checked for zero, but never set.

This is part of an effort to reduce the memory usage of go-fuse
and gocryptfs. Details can be seen at
https://github.com/rfjakob/gocryptfs/issues/132 .