### PR TITLE
Initialize the loops waitGroup when initializing the server

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -187,6 +187,10 @@ func NewServer(fs RawFileSystem, mountPoint string, opts *MountOptions) (*Server
 		// TODO - unmount as well?
 		return nil, fmt.Errorf("init: %s", code)
 	}
+	// Make sure Unmount() will wait for a corresponding Serve() to finish;
+	// Initializing the waitGroup cannot happen in Serve() as the caller can
+	// never be sure loop is initialized before calling Unmount()
+	ms.loops.Add(1)
 	return ms, nil
 }
 
@@ -321,7 +325,6 @@ func (ms *Server) recordStats(req *request) {
 //
 // Each filesystem operation executes in a separate goroutine.
 func (ms *Server) Serve() {
-	ms.loops.Add(1)
 	ms.loop(false)
 	ms.loops.Wait()
 


### PR DESCRIPTION
Otherwise, the Serve() and Unmount() calls will race calling
loops.Add(1) and loops.Wait() and the outcome is undefined.

Signed-off-by: Shayan Pooya <shayan@arista.com>