### PR TITLE
Remove out of date comment

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -586,7 +586,6 @@ func init() {
 // WaitMount waits for the first request to be served. Use this to
 // avoid racing between accessing the (empty or not yet mounted)
 // mountpoint, and the OS trying to setup the user-space mount.
-// Currently, this call only necessary on OSX.
 func (ms *Server) WaitMount() error {
 	err := <-ms.ready
 	if err != nil {


### PR DESCRIPTION
With golang 1.9, calling WaitMount is necessary to avoid hitting the
deadlock mentioned in #165 in tests where a single process acts as
both the fuse daemon and the client.

Signed-off-by: Shayan Pooya <shayan@arista.com>