### PR TITLE
debug output: fix blank line after READDIRPLUS

### DIFF
--- a/fuse/request.go
+++ b/fuse/request.go
@@ -115,7 +115,7 @@ func (r *request) OutputDebug() string {
 			if r.fdData != nil {
 				spl = " (fd data)"
 			}
-			flatStr = fmt.Sprintf(" %d bytes data%s\n", r.flatDataSize(), spl)
+			flatStr = fmt.Sprintf(" %d bytes data%s", r.flatDataSize(), spl)
 		}
 	}
 


### PR DESCRIPTION
Trivial patch that fixes a blank line in the debug output.

Before:
```
  2017/10/03 20:25:56 Dispatch 602: READDIRPLUS, NodeId: 1. data: {Fh 2 off 0 sz 4096  L 0 DIRECTORY,NONBLOCK,0x8000}
  2017/10/03 20:25:56 Serialize 602: READDIRPLUS code: OK value:  832 bytes data

  2017/10/03 20:25:56 Dispatch 603: GETXATTR, NodeId: 7. data: {sz 0} names: [system.posix_acl_access] 24 bytes
  2017/10/03 20:25:56 Serialize 603: GETXATTR code: 61=no data available value:
```
After:
```
2017/10/03 21:02:46 Dispatch 22: READDIRPLUS, NodeId: 1. data: {Fh 2 off 0 sz 4096  L 0 RDONLY,0x8000} 
2017/10/03 21:02:46 Serialize 22: READDIRPLUS code: OK value:  648 bytes data
2017/10/03 21:02:46 Dispatch 23: READDIRPLUS, NodeId: 1. data: {Fh 2 off 4 sz 4096  L 0 RDONLY,0x8000} 
2017/10/03 21:02:46 Serialize 23: READDIRPLUS code: OK value:
```