### PR TITLE
If total length of data is less than off read entire data slice

### DIFF
--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -49,6 +49,10 @@ func (f *dataFile) Read(buf []byte, off int64) (res fuse.ReadResult, code fuse.S
 		end = len(f.data)
 	}
 
+	if off > int64(len(f.data)) {
+		return fuse.ReadResultData(f.data[:end]), fuse.OK
+	}
+
 	return fuse.ReadResultData(f.data[off:end]), fuse.OK
 }
 


### PR DESCRIPTION
## Description
While running this I was experiencing a panic on an out of range slice. I added some debugging statements and was able to determine that off was greater than the total value of `f.data`. I added this and it seems to work correctly now.

## Error
Please note, this includes the debugging statements I added to figure out what going on.
```bash
end here is  19 off here is 0
19
end here is  19 off here is 65536
19
panic: runtime error: slice bounds out of range

goroutine 6 [running]:
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/nodefs.(*dataFile).Read(0xc4201a2240, 0xc4202a6000, 0x1000, 0x1000, 0x10000, 0xc420082720, 0x4, 0xc4201cc240)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/nodefs/files.go:56 +0x2ff
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/pathfs.(*pathInode).Read(0xc4201c60c0, 0xe8cda0, 0xc4201a2240, 0xc4202a6000, 0x1000, 0x1000, 0x10000, 0xc42009ef20, 0x1000, 0xc4202a6000, ...)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/pathfs/pathfs.go:729 +0x65
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/nodefs.(*rawBridge).Read(0xc420188210, 0xc42009ef08, 0xc4202a6000, 0x1000, 0x1000, 0x1000, 0x96f4e0, 0xc42014a610)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/nodefs/fsops.go:455 +0xda
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse.doRead(0xc4201422a0, 0xc42009ed80)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/opcode.go:321 +0x9d
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse.(*Server).handleRequest(0xc4201422a0, 0xc42009ed80, 0xc42009ed80)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/server.go:405 +0x29c
github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse.(*Server).loop(0xc4201422a0, 0xc4200d7b01)
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/server.go:377 +0x164
created by github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse.(*Server).readRequest
        /home/ec2-user/go/src/github.com/jszwedko/ec2-metadatafs/vendor/github.com/hanwen/go-fuse/fuse/server.go:285 +0x2db

```
Debugging diff:
```diff
+++ b/vendor/github.com/hanwen/go-fuse/fuse/nodefs/files.go
@@ -49,6 +49,10 @@ func (f *dataFile) Read(buf []byte, off int64) (res fuse.ReadResult, code fuse.S
                end = len(f.data)
        }

+       fmt.Println("end here is ", end, "off here is", off)
+
+       fmt.Println(len(f.data))
+
        return fuse.ReadResultData(f.data[off:end]), fuse.OK
 }
```