### PR TITLE
pathfs: simplify pathInode.GetAttr

### DIFF
--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -583,26 +583,34 @@ func (n *pathInode) GetAttr(out *fuse.Attr, file nodefs.File, context *fuse.Cont
 		// an open fd.
 		file = n.Inode().AnyFile()
 	}
-
+	// If we have found an open file, try to fstat it.
 	if file != nil {
 		code = file.GetAttr(out)
+		if code.Ok() {
+			return code
+		}
 	}
-
+	// If we don't have an open file, or fstat on it failed due to an internal
+	// error, stat by path.
 	if file == nil || code == fuse.ENOSYS || code == fuse.EBADF {
 		fi, code = n.fs.GetAttr(n.GetPath(), context)
+		if !code.Ok() {
+			return code
+		}
+		// This is a bug in the filesystem implementation, but let's not
+		// crash.
+		if fi == nil {
+			log.Printf("Bug: fs.GetAttr returned OK with nil data")
+			return fuse.EINVAL
+		}
 	}
-
-	if fi != nil {
-		n.setClientInode(fi.Ino)
-	}
-
-	if fi != nil && !fi.IsDir() && fi.Nlink == 0 {
+	// Set inode number (unless already set or disabled).
+	n.setClientInode(fi.Ino)
+	// Help filesystems that forget to set Nlink.
+	if !fi.IsDir() && fi.Nlink == 0 {
 		fi.Nlink = 1
 	}
-
-	if fi != nil {
-		*out = *fi
-	}
+	*out = *fi
 	return code
 }
 


### PR DESCRIPTION
The function was written with only a single return at
the end, which was elegant, but harder to follow.

Add early returns to handle common cases and add a few
comments.

A functional change is that we now catch when we get
OK with fi == nil and return EINVAL and log a message.
This should not happen and is a bug in the filesystem
implementation.

Passes ./all.bash and the gocryptfs test suite.