### PR TITLE
Fixing "no FUSE devices found" on macOS

### DIFF
--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -20,8 +20,15 @@ func openFUSEDevice() (*os.File, error) {
 		return nil, err
 	}
 	if len(fs) == 0 {
-		// TODO(hanwen): run the load_osxfuse command.
-		return nil, fmt.Errorf("no FUSE devices found")
+		bin := oldLoadBin
+		if _, err := os.Stat(newLoadBin); err == nil {
+			bin = newLoadBin
+		}
+		cmd := exec.Command(bin)
+		if err := cmd.Run(); err != nil {
+			return nil, err
+		}
+		return openFUSEDevice()
 	}
 	for _, fn := range fs {
 		f, err := os.OpenFile(fn, os.O_RDWR, 0)
@@ -36,6 +43,9 @@ func openFUSEDevice() (*os.File, error) {
 
 const oldMountBin = "/Library/Filesystems/osxfusefs.fs/Support/mount_osxfusefs"
 const newMountBin = "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse"
+
+const oldLoadBin = "/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs"
+const newLoadBin = "/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse"
 
 func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, err error) {
 	f, err := openFUSEDevice()

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 )
 
-func openFUSEDevice(recursive boolean) (*os.File, error) {
+func openFUSEDevice(recursive bool) (*os.File, error) {
 	fs, err := filepath.Glob("/dev/osxfuse*")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Calling `load_osxfusefs` if necessary as suggested by @bailey27 here https://github.com/rfjakob/gocryptfs/issues/15#issuecomment-264253024. All credit goes to @bailey27.