### PR TITLE
darwin: use simpleHandleMap that never reuses handle numbers

### DIFF
--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -55,7 +55,7 @@ func NewFileSystemConnector(root Node, opts *Options) (c *FileSystemConnector) {
 	if opts == nil {
 		opts = NewOptions()
 	}
-	c.inodeMap = newPortableHandleMap()
+	c.inodeMap = newHandleMap()
 	c.rootNode = newInode(true, root)
 
 	c.verify()

--- a/fuse/nodefs/handle.go
+++ b/fuse/nodefs/handle.go
@@ -9,6 +9,9 @@ import (
 	"sync"
 )
 
+// newHandleMap stores the currently active handleMap implementation.
+var newHandleMap = newPortableHandleMap
+
 // HandleMap translates objects in Go space to 64-bit handles that can
 // be given out to -say- the linux kernel as NodeIds.
 //
@@ -66,7 +69,7 @@ type portableHandleMap struct {
 	freeIds []uint64
 }
 
-func newPortableHandleMap() *portableHandleMap {
+func newPortableHandleMap() handleMap {
 	return &portableHandleMap{
 		// Avoid handing out ID 0 and 1.
 		handles: []*handled{nil, nil},

--- a/fuse/nodefs/handle_darwin.go
+++ b/fuse/nodefs/handle_darwin.go
@@ -1,0 +1,15 @@
+// Copyright 2018 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package nodefs
+
+func init() {
+	// darwin / osxfuse has problems with handle reuse, we get
+	// the kernel message
+	//    osxfuse: vnode changed generation
+	// and errors returned to the user. simpleHandleMap never reuses handles
+	// which seems to keep osxfuse happy.
+	// https://github.com/hanwen/go-fuse/issues/204
+	newHandleMap = newSimpleHandleMap
+}

--- a/fuse/nodefs/handle_simple.go
+++ b/fuse/nodefs/handle_simple.go
@@ -1,0 +1,97 @@
+// Copyright 2018 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package nodefs
+
+import (
+	"log"
+	"sync"
+)
+
+// simpleHandleMap is a simple, low-performance handle map that never reuses
+// handle numbers.
+type simpleHandleMap struct {
+	sync.Mutex
+	entries    map[uint64]*handled
+	nextHandle uint64
+}
+
+func newSimpleHandleMap() handleMap {
+	return &simpleHandleMap{
+		entries: make(map[uint64]*handled),
+		// Avoid handing out ID 0 and 1, like portableHandleMap does.
+		nextHandle: 2,
+	}
+}
+
+func (s *simpleHandleMap) Register(obj *handled) (handle, generation uint64) {
+	s.Lock()
+	defer s.Unlock()
+	// The object already has a handle
+	if obj.count != 0 {
+		if obj.handle == 0 {
+			log.Panicf("bug: count=%d handle=%d", obj.count, obj.handle)
+		}
+		obj.count++
+		return obj.handle, 0
+	}
+	// Create a new handle
+	obj.count = 1
+	obj.handle = s.nextHandle
+	s.entries[s.nextHandle] = obj
+	s.nextHandle++
+	return obj.handle, 0
+}
+
+// Count returns the number of currently used handles
+func (s *simpleHandleMap) Count() int {
+	s.Lock()
+	defer s.Unlock()
+	return len(s.entries)
+}
+
+// Handle gets the object's uint64 handle.
+func (s *simpleHandleMap) Handle(obj *handled) (handle uint64) {
+	s.Lock()
+	defer s.Unlock()
+	if obj.count == 0 {
+		return 0
+	}
+	return obj.handle
+}
+
+// Decode retrieves a stored object from its uint64 handle.
+func (s *simpleHandleMap) Decode(handle uint64) *handled {
+	s.Lock()
+	defer s.Unlock()
+	return s.entries[handle]
+}
+
+// Forget decrements the reference counter for "handle" by "count" and drops
+// the object if the refcount reaches zero.
+// Returns a boolean whether the object was dropped and the object itself.
+func (s *simpleHandleMap) Forget(handle uint64, count int) (forgotten bool, obj *handled) {
+	s.Lock()
+	defer s.Unlock()
+	obj = s.entries[handle]
+	obj.count -= count
+	if obj.count < 0 {
+		log.Panicf("underflow: handle %d, count %d,  obj.count %d", handle, count, obj.count)
+	}
+	if obj.count > 0 {
+		return false, obj
+	}
+	// count is zero, drop the reference
+	delete(s.entries, handle)
+	obj.handle = 0
+	return true, obj
+}
+
+// Has checks if the uint64 handle is stored.
+func (s *simpleHandleMap) Has(handle uint64) bool {
+	s.Lock()
+	defer s.Unlock()
+	_, ok := s.entries[handle]
+	return ok
+}

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -220,7 +220,7 @@ func (n *Inode) rmChild(name string) *Inode {
 // Can only be called on untouched root inodes.
 func (n *Inode) mountFs(opts *Options) {
 	n.mountPoint = &fileSystemMount{
-		openFiles:  newPortableHandleMap(),
+		openFiles:  newHandleMap(),
 		mountInode: n,
 		options:    opts,
 	}


### PR DESCRIPTION
Implement simpleHandleMap that never reuses handle numbers and
uses a simple map to track handle numbers.

This seems to get rid of the

	osxfuse: vnode changed generation

errors we are seeing on darwin, while sacrificing
some performance.

I have tested simpleHandleMap on darwin and linux,
seems to work fine.

https://github.com/rfjakob/gocryptfs/issues/213
https://github.com/hanwen/go-fuse/issues/204
https://github.com/osxfuse/osxfuse/issues/482