### PR TITLE
handleMap: track per-handle generation number

### DIFF
--- a/fuse/test/cache_test.go
+++ b/fuse/test/cache_test.go
@@ -95,7 +95,7 @@ func TestFopenKeepCache(t *testing.T) {
 	}
 
 	if minor := pathfs.Connector().Server().KernelSettings().Minor; minor < 12 {
-		t.Skip("protocol v%d has no notify support.", minor)
+		t.Skipf("protocol v%d has no notify support.", minor)
 	}
 
 	code := pathfs.EntryNotify("", "file.txt")


### PR DESCRIPTION
Fixes https://github.com/hanwen/go-fuse/issues/204 properly.