### PR TITLE
nodefs: Make Create call File.GetAttr if possible - fixes #207

### DIFF
--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -282,7 +282,7 @@ func (c *rawBridge) Mknod(input *fuse.MknodIn, name string, out *fuse.EntryOut) 
 
 	child, code := parent.fsInode.Mknod(name, input.Mode, uint32(input.Rdev), &input.Context)
 	if code.Ok() {
-		c.childLookup(out, child, &input.Context)
+		c.childLookup(out, child, nil, &input.Context)
 		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
 	}
 	return code
@@ -293,7 +293,7 @@ func (c *rawBridge) Mkdir(input *fuse.MkdirIn, name string, out *fuse.EntryOut) 
 
 	child, code := parent.fsInode.Mkdir(name, input.Mode, &input.Context)
 	if code.Ok() {
-		c.childLookup(out, child, &input.Context)
+		c.childLookup(out, child, nil, &input.Context)
 		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
 	}
 	return code
@@ -314,7 +314,7 @@ func (c *rawBridge) Symlink(header *fuse.InHeader, pointedTo string, linkName st
 
 	child, code := parent.fsInode.Symlink(linkName, pointedTo, &header.Context)
 	if code.Ok() {
-		c.childLookup(out, child, &header.Context)
+		c.childLookup(out, child, nil, &header.Context)
 		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &header.Context)
 	}
 	return code
@@ -349,7 +349,7 @@ func (c *rawBridge) Link(input *fuse.LinkIn, name string, out *fuse.EntryOut) (c
 
 	child, code := parent.fsInode.Link(name, existing.fsInode, &input.Context)
 	if code.Ok() {
-		c.childLookup(out, child, &input.Context)
+		c.childLookup(out, child, nil, &input.Context)
 		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
 	}
 
@@ -368,7 +368,7 @@ func (c *rawBridge) Create(input *fuse.CreateIn, name string, out *fuse.CreateOu
 		return code
 	}
 
-	c.childLookup(&out.EntryOut, child, &input.Context)
+	c.childLookup(&out.EntryOut, child, f, &input.Context)
 	handle, opened := parent.mount.registerFileHandle(child, nil, f, input.Flags)
 
 	out.OpenOut.OpenFlags = opened.FuseFlags


### PR DESCRIPTION
Before this fix, Create was calling GetAttr (indirectly) which ends up
doing a GetAttr on the file system, not the file handle.  This is
inefficient and causes problems for clients which haven't added the
open file to the directory by the time the call returns.

After this fix Create via childLookup calls GetAttr on the file handle
directly if available.