### PR TITLE
Changed FromStatfsT on Darwin to fix df output 

### DIFF
--- a/fuse/types_darwin.go
+++ b/fuse/types_darwin.go
@@ -148,6 +148,6 @@ func (s *StatfsOut) FromStatfsT(statfs *syscall.Statfs_t) {
 	s.Bavail = statfs.Bavail
 	s.Files = statfs.Files
 	s.Ffree = statfs.Ffree
-	s.Bsize = uint32(statfs.Iosize) // Iosize translates to Bsize: the optimal transfer size.
-	s.Frsize = s.Bsize              // Bsize translates to Frsize: the minimum transfer size.
+	s.Bsize = uint32(statfs.Bsize)
+	s.Frsize = uint32(statfs.Bsize)
 }


### PR DESCRIPTION
`osxfuse/fuse` provides a possibility to implement a standard and an extended `statfs` calls, the previous mapping is relevant for the `statfs_x` call, which is not implemented in `go-fuse` yet. 

https://github.com/osxfuse/fuse/blob/1cd72d7333ce84975470f5d865383422034baa7d/include/fuse.h#L620
https://github.com/osxfuse/fuse/blob/abc35f85fdede186ed164082bd71fc1217d2f58f/lib/fuse.c#L4094

This change maps the Block Size to both upper-level block size and fragment size.

Previously it resulted into incorrect reporting of total and free space in the "df" command.