### PR TITLE
nodefs: Fix godoc for NewReadOnlyFile

### DIFF
--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -218,8 +218,7 @@ func (f *loopbackFile) GetAttr(a *fuse.Attr) fuse.Status {
 
 ////////////////////////////////////////////////////////////////
 
-// NewReadOnlyFile wraps a File so all read/write operations are
-// denied.
+// NewReadOnlyFile wraps a File so all write operations are denied.
 func NewReadOnlyFile(f File) File {
 	return &readOnlyFile{File: f}
 }


### PR DESCRIPTION
The File returned for NewReadOnlyFile only blocks writes not reads and
writes.