### PR TITLE
fuse/nodefs: add LookupKnownChildren mount option

### DIFF
--- a/fuse/nodefs/api.go
+++ b/fuse/nodefs/api.go
@@ -38,7 +38,8 @@ type Node interface {
 	OnUnmount()
 
 	// Lookup finds a child node to this node; it is only called
-	// for directory Nodes.
+	// for directory Nodes. Lookup may be called on nodes that are
+	// already known.
 	Lookup(out *fuse.Attr, name string, context *fuse.Context) (*Inode, fuse.Status)
 
 	// Deletable() should return true if this node may be discarded once
@@ -187,4 +188,9 @@ type Options struct {
 
 	// If set, print debug information.
 	Debug bool
+
+	// If set, issue Lookup rather than GetAttr calls for known
+	// children. This allows the filesystem to update its inode
+	// hierarchy in response to kernel calls.
+	LookupKnownChildren bool
 }

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -85,7 +85,7 @@ func (c *FileSystemConnector) internalLookup(out *fuse.Attr, parent *Inode, name
 		return c.lookupMountUpdate(out, child.mountPoint)
 	}
 
-	if child != nil {
+	if child != nil && !parent.mount.options.LookupKnownChildren {
 		code = child.fsInode.GetAttr(out, nil, &header.Context)
 	} else {
 		child, code = parent.fsInode.Lookup(out, name, &header.Context)

--- a/fuse/test/loopback_test.go
+++ b/fuse/test/loopback_test.go
@@ -95,10 +95,11 @@ func NewTestCase(t *testing.T) *testCase {
 		ClientInodes: true})
 	tc.connector = nodefs.NewFileSystemConnector(tc.pathFs.Root(),
 		&nodefs.Options{
-			EntryTimeout:    testTtl,
-			AttrTimeout:     testTtl,
-			NegativeTimeout: 0.0,
-			Debug:           testutil.VerboseTest(),
+			EntryTimeout:        testTtl,
+			AttrTimeout:         testTtl,
+			NegativeTimeout:     0.0,
+			Debug:               testutil.VerboseTest(),
+			LookupKnownChildren: true,
 		})
 	tc.state, err = fuse.NewServer(
 		fuse.NewRawFileSystem(tc.connector.RawFS()), tc.mnt, &fuse.MountOptions{

--- a/fuse/test/node_test.go
+++ b/fuse/test/node_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
+)
+
+type rootNode struct {
+	nodefs.Node
+	// represents backing store.
+	mu      sync.Mutex
+	backing map[string]string
+}
+
+type blobNode struct {
+	nodefs.Node
+	content string
+}
+
+func (n *blobNode) GetAttr(out *fuse.Attr, file nodefs.File, context *fuse.Context) (code fuse.Status) {
+	out.Mode = fuse.S_IFREG | 0777
+	out.Size = uint64(len(n.content))
+	return fuse.OK
+}
+
+func (n *rootNode) Lookup(out *fuse.Attr, name string, context *fuse.Context) (*nodefs.Inode, fuse.Status) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	want := n.backing[name]
+
+	if want == "" {
+		return nil, fuse.ENOENT
+	}
+
+	ch := n.Inode().GetChild(name)
+	var blob *blobNode
+	if ch != nil {
+		blob = ch.Node().(*blobNode)
+		if blob.content != want {
+			n.Inode().RmChild(name)
+			ch = nil
+		}
+	}
+
+	if ch == nil {
+		blob = &blobNode{nodefs.NewDefaultNode(), want}
+		ch = n.Inode().NewChild(name, false, blob)
+	}
+
+	status := blob.GetAttr(out, nil, nil)
+	return ch, status
+}
+
+func TestUpdateNode(t *testing.T) {
+	dir := testutil.TempDir()
+	root := &rootNode{
+		Node:    nodefs.NewDefaultNode(),
+		backing: map[string]string{"a": "aaa"},
+	}
+
+	opts := nodefs.NewOptions()
+	opts.Debug = testutil.VerboseTest()
+	opts.EntryTimeout = 0
+	opts.LookupKnownChildren = true
+
+	server, _, err := nodefs.MountRoot(dir, root, opts)
+	if err != nil {
+		t.Fatalf("MountRoot: %v", err)
+	}
+	go server.Serve()
+
+	if err := server.WaitMount(); err != nil {
+		t.Fatalf("WaitMount: %v", err)
+	}
+
+	defer server.Unmount()
+
+	fi1, err := os.Lstat(dir + "/a")
+	if err != nil {
+		t.Fatal("Lstat", err)
+	}
+
+	if fi1.Size() != 3 {
+		t.Fatalf("got %v, want sz 3", fi1.Size())
+	}
+
+	root.mu.Lock()
+	root.backing["a"] = "x"
+	root.mu.Unlock()
+
+	fi2, err := os.Lstat(dir + "/a")
+	if err != nil {
+		t.Fatal("Lstat", err)
+	}
+
+	if fi2.Size() != 1 {
+		t.Fatalf("got %#v, want sz 1", fi2)
+	}
+}


### PR DESCRIPTION
WIP/DONOTSUBMIT: should use LookupKnownChildren in all example code,
as it is the better default.