### PR TITLE
Make it possible to remove the locking capabilities from server flags

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -74,6 +74,9 @@ type MountOptions struct {
 	// Xattr operations at all.
 	DisableXAttrs bool
 
+	// If set, disables the CAP_FLOCK_LOCKS and CAP_POSIX_LOCKS capabilities
+	DisableLocks bool
+
 	// If set, print debugging information.
 	Debug bool
 }

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -85,6 +85,10 @@ func doInit(server *Server, req *request) {
 	server.kernelSettings.Flags = input.Flags & (CAP_ASYNC_READ | CAP_BIG_WRITES | CAP_FILE_OPS |
 		CAP_AUTO_INVAL_DATA | CAP_READDIRPLUS | CAP_NO_OPEN_SUPPORT | CAP_FLOCK_LOCKS | CAP_POSIX_LOCKS)
 
+	if server.opts.DisableLocks {
+		server.kernelSettings.Flags = server.kernelSettings.Flags &^ (CAP_FLOCK_LOCKS | CAP_POSIX_LOCKS)
+	}
+
 	if input.Minor >= 13 {
 		server.setSplice()
 	}


### PR DESCRIPTION
Since https://github.com/hanwen/go-fuse/commit/1eca9006d0f2410c01fe65d69c536a36c146c460, fully implementing `GetLk`, `SetLk`, and `SetLkw` has become a requirement which breaks existing use-cases of this library, especially when it's not backed by an actual filesystem.

This PR is a first attempt at making this behavior configurable and allowing client implementations to disable these capabilities in fuse.Server.

If you believe there's a better way to achieve the same, please let me know and I'll update the PR accordingly.

This will address https://github.com/hanwen/go-fuse/issues/223