### PR TITLE
syscall-based unmount leaves garbage in /etc/mtab

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -80,9 +80,6 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 }
 
 func unmount(mountPoint string) (err error) {
-	if os.Geteuid() == 0 {
-		return syscall.Unmount(mountPoint, 0)
-	}
 	bin, err := fusermountBinary()
 	if err != nil {
 		return err


### PR DESCRIPTION
On a Linux system with go-fuse program running as root, the mount is
performed by calling /bin/fusermount, and the unmount is performed with
syscall.Unmount()

This creates a problem on systems (CentOS 6) with a static-but-edited-by-mount
/etc/mtab file.

 - fusermount adds a line to mtab when the go-fuse program starts
 - syscall.Unmount() doesn't edit the file on program exit
 - subsequent invocations of the program fail to mount with:

    "Mount fail: fusermount exited with code 256"

Deleting the now-inaccurate mtab entry clears things up.

There's probably a workaround by adding "-n" option so that mount doesn't
edit mtab in the first place, but it's not obvious where to insert that when
starting with the hello.go example.