### PR TITLE
fuse: add support for Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+
+language: go
+go_import_path: github.com/hanwen/go-fuse
+
+go:
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - master
+
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
+
+before_install:
+  - sudo apt-get install -qq pkg-config fuse
+  - sudo modprobe fuse
+  - sudo chmod 666 /dev/fuse
+  - sudo chown root:$USER /etc/fuse.conf
+
+install:
+  - go get -t -race ./...
+
+script:
+  - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GO-FUSE
 
+[![Build Status](https://travis-ci.org/hanwen/go-fuse.svg?branch=master)](https://travis-ci.org/hanwen/go-fuse)
+[![GoDoc](https://godoc.org/github.com/hanwen/go-fuse?status.svg)](https://godoc.org/github.com/hanwen/go-fuse)
+
 native bindings for the FUSE kernel module.
 
 ## Highlights

--- a/fuse/test/file_lock_test.go
+++ b/fuse/test/file_lock_test.go
@@ -133,7 +133,7 @@ func TestFlockInvoked(t *testing.T) {
 	root := nodefs.NewDefaultNode()
 	conn := nodefs.NewFileSystemConnector(root, opts)
 	mountOpts := fuse.MountOptions{
-		EnableLocks: true
+		EnableLocks: true,
 	}
 	s, err := fuse.NewServer(conn.RawFS(), dir, &mountOpts)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/hanwen/go-fuse
+
+require golang.org/x/sys v0.0.0-20180830151530-49385e6e1522

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This CL adds support for Go modules, now in preview-mode in Go1.11.
This CL also adds support for continuous integration via Travis-CI (and the obligatory build status badge)