### PR TITLE
pathfs: fix possible nil pointer dereference in GetAttr

### DIFF
--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -596,6 +596,10 @@ func (n *pathInode) GetAttr(out *fuse.Attr, file nodefs.File, context *fuse.Cont
 		if code.Ok() {
 			return code
 		}
+		// ENOSYS and EBADF are retried below. Error out for other codes.
+		if code != fuse.ENOSYS && code != fuse.EBADF {
+			return code
+		}
 	}
 	// If we don't have an open file, or fstat on it failed due to an internal
 	// error, stat by path.


### PR DESCRIPTION
gocryptfs user Felix Lechner reported a nil pointer dereference
in GetAttr: https://github.com/rfjakob/gocryptfs/issues/260

The crash is in line

	n.setClientInode(fi.Ino)

because fi is nil.

This can happen when file.GetAttr() returns an error code other than
ENOSYS and EBADF. For gocryptfs, this can only happen when an open
file descriptor breaks. In this case it was triggered by a failing
NFS volume.

Fix the crash by erroring out for error codes that are not handled
by the retry-by-path logic.