### PR TITLE
fuse: A bit better package documentation rendering in godoc

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -5,7 +5,6 @@
 // The fuse package provides APIs to implement filesystems in
 // userspace.  Typically, each call of the API happens in its own
 // goroutine, so take care to make the file system thread-safe.
-
 package fuse
 
 // Types for users to implement.


### PR DESCRIPTION
Current state is: fuse's godoc package-level description is completely
empty because there is a blank link between package-level description
and package clause.

Yes, a user still has to go through api.go and read it in full, but
having at least something for the description is a better start, and
removing one line is easy.

We already do it this way e.g. for nodefs and in other places.