### PR TITLE
fuse: Correct NOTIFY constants/operation names

### DIFF
--- a/fuse/misc.go
+++ b/fuse/misc.go
@@ -23,9 +23,9 @@ func (code Status) String() string {
 			"NOTIFY_POLL",
 			"NOTIFY_INVAL_INODE",
 			"NOTIFY_INVAL_ENTRY",
-			"NOTIFY_INVAL_STORE",
-			"NOTIFY_INVAL_RETRIEVE",
-			"NOTIFY_INVAL_DELETE",
+			"NOTIFY_STORE_CACHE",
+			"NOTIFY_RETRIEVE_CACHE",
+			"NOTIFY_DELETE",
 		}[-code]
 	}
 	return fmt.Sprintf("%d=%v", int(code), syscall.Errno(code))

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -58,10 +58,10 @@ const (
 	_OP_FUSE_RENAME2 = int32(45) // protocol version 23.
 
 	// The following entries don't have to be compatible across Go-FUSE versions.
-	_OP_NOTIFY_ENTRY  = int32(100)
-	_OP_NOTIFY_INODE  = int32(101)
-	_OP_NOTIFY_STORE  = int32(102)
-	_OP_NOTIFY_DELETE = int32(103) // protocol version 18
+	_OP_NOTIFY_INVAL_ENTRY = int32(100)
+	_OP_NOTIFY_INVAL_INODE = int32(101)
+	_OP_NOTIFY_STORE_CACHE = int32(102)
+	_OP_NOTIFY_DELETE      = int32(103) // protocol version 18
 
 	_OPCODE_COUNT = int32(104)
 )
@@ -446,7 +446,7 @@ func init() {
 		operationHandlers[i] = &operationHandler{Name: "UNKNOWN"}
 	}
 
-	fileOps := []int32{_OP_READLINK, _OP_NOTIFY_ENTRY, _OP_NOTIFY_DELETE}
+	fileOps := []int32{_OP_READLINK, _OP_NOTIFY_INVAL_ENTRY, _OP_NOTIFY_DELETE}
 	for _, op := range fileOps {
 		operationHandlers[op].FileNameOut = true
 	}
@@ -490,79 +490,79 @@ func init() {
 	}
 
 	for op, sz := range map[int32]uintptr{
-		_OP_LOOKUP:        unsafe.Sizeof(EntryOut{}),
-		_OP_GETATTR:       unsafe.Sizeof(AttrOut{}),
-		_OP_SETATTR:       unsafe.Sizeof(AttrOut{}),
-		_OP_SYMLINK:       unsafe.Sizeof(EntryOut{}),
-		_OP_MKNOD:         unsafe.Sizeof(EntryOut{}),
-		_OP_MKDIR:         unsafe.Sizeof(EntryOut{}),
-		_OP_LINK:          unsafe.Sizeof(EntryOut{}),
-		_OP_OPEN:          unsafe.Sizeof(OpenOut{}),
-		_OP_WRITE:         unsafe.Sizeof(WriteOut{}),
-		_OP_STATFS:        unsafe.Sizeof(StatfsOut{}),
-		_OP_GETXATTR:      unsafe.Sizeof(GetXAttrOut{}),
-		_OP_LISTXATTR:     unsafe.Sizeof(GetXAttrOut{}),
-		_OP_INIT:          unsafe.Sizeof(InitOut{}),
-		_OP_OPENDIR:       unsafe.Sizeof(OpenOut{}),
-		_OP_GETLK:         unsafe.Sizeof(LkOut{}),
-		_OP_CREATE:        unsafe.Sizeof(CreateOut{}),
-		_OP_BMAP:          unsafe.Sizeof(_BmapOut{}),
-		_OP_IOCTL:         unsafe.Sizeof(_IoctlOut{}),
-		_OP_POLL:          unsafe.Sizeof(_PollOut{}),
-		_OP_NOTIFY_ENTRY:  unsafe.Sizeof(NotifyInvalEntryOut{}),
-		_OP_NOTIFY_INODE:  unsafe.Sizeof(NotifyInvalInodeOut{}),
-		_OP_NOTIFY_STORE:  unsafe.Sizeof(NotifyStoreOut{}),
-		_OP_NOTIFY_DELETE: unsafe.Sizeof(NotifyInvalDeleteOut{}),
+		_OP_LOOKUP:             unsafe.Sizeof(EntryOut{}),
+		_OP_GETATTR:            unsafe.Sizeof(AttrOut{}),
+		_OP_SETATTR:            unsafe.Sizeof(AttrOut{}),
+		_OP_SYMLINK:            unsafe.Sizeof(EntryOut{}),
+		_OP_MKNOD:              unsafe.Sizeof(EntryOut{}),
+		_OP_MKDIR:              unsafe.Sizeof(EntryOut{}),
+		_OP_LINK:               unsafe.Sizeof(EntryOut{}),
+		_OP_OPEN:               unsafe.Sizeof(OpenOut{}),
+		_OP_WRITE:              unsafe.Sizeof(WriteOut{}),
+		_OP_STATFS:             unsafe.Sizeof(StatfsOut{}),
+		_OP_GETXATTR:           unsafe.Sizeof(GetXAttrOut{}),
+		_OP_LISTXATTR:          unsafe.Sizeof(GetXAttrOut{}),
+		_OP_INIT:               unsafe.Sizeof(InitOut{}),
+		_OP_OPENDIR:            unsafe.Sizeof(OpenOut{}),
+		_OP_GETLK:              unsafe.Sizeof(LkOut{}),
+		_OP_CREATE:             unsafe.Sizeof(CreateOut{}),
+		_OP_BMAP:               unsafe.Sizeof(_BmapOut{}),
+		_OP_IOCTL:              unsafe.Sizeof(_IoctlOut{}),
+		_OP_POLL:               unsafe.Sizeof(_PollOut{}),
+		_OP_NOTIFY_INVAL_ENTRY: unsafe.Sizeof(NotifyInvalEntryOut{}),
+		_OP_NOTIFY_INVAL_INODE: unsafe.Sizeof(NotifyInvalInodeOut{}),
+		_OP_NOTIFY_STORE_CACHE: unsafe.Sizeof(NotifyStoreOut{}),
+		_OP_NOTIFY_DELETE:      unsafe.Sizeof(NotifyInvalDeleteOut{}),
 	} {
 		operationHandlers[op].OutputSize = sz
 	}
 
 	for op, v := range map[int32]string{
-		_OP_LOOKUP:        "LOOKUP",
-		_OP_FORGET:        "FORGET",
-		_OP_BATCH_FORGET:  "BATCH_FORGET",
-		_OP_GETATTR:       "GETATTR",
-		_OP_SETATTR:       "SETATTR",
-		_OP_READLINK:      "READLINK",
-		_OP_SYMLINK:       "SYMLINK",
-		_OP_MKNOD:         "MKNOD",
-		_OP_MKDIR:         "MKDIR",
-		_OP_UNLINK:        "UNLINK",
-		_OP_RMDIR:         "RMDIR",
-		_OP_RENAME:        "RENAME",
-		_OP_LINK:          "LINK",
-		_OP_OPEN:          "OPEN",
-		_OP_READ:          "READ",
-		_OP_WRITE:         "WRITE",
-		_OP_STATFS:        "STATFS",
-		_OP_RELEASE:       "RELEASE",
-		_OP_FSYNC:         "FSYNC",
-		_OP_SETXATTR:      "SETXATTR",
-		_OP_GETXATTR:      "GETXATTR",
-		_OP_LISTXATTR:     "LISTXATTR",
-		_OP_REMOVEXATTR:   "REMOVEXATTR",
-		_OP_FLUSH:         "FLUSH",
-		_OP_INIT:          "INIT",
-		_OP_OPENDIR:       "OPENDIR",
-		_OP_READDIR:       "READDIR",
-		_OP_RELEASEDIR:    "RELEASEDIR",
-		_OP_FSYNCDIR:      "FSYNCDIR",
-		_OP_GETLK:         "GETLK",
-		_OP_SETLK:         "SETLK",
-		_OP_SETLKW:        "SETLKW",
-		_OP_ACCESS:        "ACCESS",
-		_OP_CREATE:        "CREATE",
-		_OP_INTERRUPT:     "INTERRUPT",
-		_OP_BMAP:          "BMAP",
-		_OP_DESTROY:       "DESTROY",
-		_OP_IOCTL:         "IOCTL",
-		_OP_POLL:          "POLL",
-		_OP_NOTIFY_ENTRY:  "NOTIFY_ENTRY",
-		_OP_NOTIFY_INODE:  "NOTIFY_INODE",
-		_OP_NOTIFY_STORE:  "NOTIFY_STORE",
-		_OP_NOTIFY_DELETE: "NOTIFY_DELETE",
-		_OP_FALLOCATE:     "FALLOCATE",
-		_OP_READDIRPLUS:   "READDIRPLUS",
+		_OP_LOOKUP:             "LOOKUP",
+		_OP_FORGET:             "FORGET",
+		_OP_BATCH_FORGET:       "BATCH_FORGET",
+		_OP_GETATTR:            "GETATTR",
+		_OP_SETATTR:            "SETATTR",
+		_OP_READLINK:           "READLINK",
+		_OP_SYMLINK:            "SYMLINK",
+		_OP_MKNOD:              "MKNOD",
+		_OP_MKDIR:              "MKDIR",
+		_OP_UNLINK:             "UNLINK",
+		_OP_RMDIR:              "RMDIR",
+		_OP_RENAME:             "RENAME",
+		_OP_LINK:               "LINK",
+		_OP_OPEN:               "OPEN",
+		_OP_READ:               "READ",
+		_OP_WRITE:              "WRITE",
+		_OP_STATFS:             "STATFS",
+		_OP_RELEASE:            "RELEASE",
+		_OP_FSYNC:              "FSYNC",
+		_OP_SETXATTR:           "SETXATTR",
+		_OP_GETXATTR:           "GETXATTR",
+		_OP_LISTXATTR:          "LISTXATTR",
+		_OP_REMOVEXATTR:        "REMOVEXATTR",
+		_OP_FLUSH:              "FLUSH",
+		_OP_INIT:               "INIT",
+		_OP_OPENDIR:            "OPENDIR",
+		_OP_READDIR:            "READDIR",
+		_OP_RELEASEDIR:         "RELEASEDIR",
+		_OP_FSYNCDIR:           "FSYNCDIR",
+		_OP_GETLK:              "GETLK",
+		_OP_SETLK:              "SETLK",
+		_OP_SETLKW:             "SETLKW",
+		_OP_ACCESS:             "ACCESS",
+		_OP_CREATE:             "CREATE",
+		_OP_INTERRUPT:          "INTERRUPT",
+		_OP_BMAP:               "BMAP",
+		_OP_DESTROY:            "DESTROY",
+		_OP_IOCTL:              "IOCTL",
+		_OP_POLL:               "POLL",
+		_OP_NOTIFY_INVAL_ENTRY: "NOTIFY_INVAL_ENTRY",
+		_OP_NOTIFY_INVAL_INODE: "NOTIFY_INVAL_INODE",
+		_OP_NOTIFY_STORE_CACHE: "NOTIFY_STORE",
+		_OP_NOTIFY_DELETE:      "NOTIFY_DELETE",
+		_OP_FALLOCATE:          "FALLOCATE",
+		_OP_READDIRPLUS:        "READDIRPLUS",
 	} {
 		operationHandlers[op].Name = v
 	}
@@ -612,22 +612,22 @@ func init() {
 
 	// Outputs.
 	for op, f := range map[int32]castPointerFunc{
-		_OP_LOOKUP:        func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
-		_OP_OPEN:          func(ptr unsafe.Pointer) interface{} { return (*OpenOut)(ptr) },
-		_OP_OPENDIR:       func(ptr unsafe.Pointer) interface{} { return (*OpenOut)(ptr) },
-		_OP_GETATTR:       func(ptr unsafe.Pointer) interface{} { return (*AttrOut)(ptr) },
-		_OP_CREATE:        func(ptr unsafe.Pointer) interface{} { return (*CreateOut)(ptr) },
-		_OP_LINK:          func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
-		_OP_SETATTR:       func(ptr unsafe.Pointer) interface{} { return (*AttrOut)(ptr) },
-		_OP_INIT:          func(ptr unsafe.Pointer) interface{} { return (*InitOut)(ptr) },
-		_OP_MKDIR:         func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
-		_OP_NOTIFY_ENTRY:  func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalEntryOut)(ptr) },
-		_OP_NOTIFY_INODE:  func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalInodeOut)(ptr) },
-		_OP_NOTIFY_STORE:  func(ptr unsafe.Pointer) interface{} { return (*NotifyStoreOut)(ptr) },
-		_OP_NOTIFY_DELETE: func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalDeleteOut)(ptr) },
-		_OP_STATFS:        func(ptr unsafe.Pointer) interface{} { return (*StatfsOut)(ptr) },
-		_OP_SYMLINK:       func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
-		_OP_GETLK:         func(ptr unsafe.Pointer) interface{} { return (*LkOut)(ptr) },
+		_OP_LOOKUP:             func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
+		_OP_OPEN:               func(ptr unsafe.Pointer) interface{} { return (*OpenOut)(ptr) },
+		_OP_OPENDIR:            func(ptr unsafe.Pointer) interface{} { return (*OpenOut)(ptr) },
+		_OP_GETATTR:            func(ptr unsafe.Pointer) interface{} { return (*AttrOut)(ptr) },
+		_OP_CREATE:             func(ptr unsafe.Pointer) interface{} { return (*CreateOut)(ptr) },
+		_OP_LINK:               func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
+		_OP_SETATTR:            func(ptr unsafe.Pointer) interface{} { return (*AttrOut)(ptr) },
+		_OP_INIT:               func(ptr unsafe.Pointer) interface{} { return (*InitOut)(ptr) },
+		_OP_MKDIR:              func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
+		_OP_NOTIFY_INVAL_ENTRY: func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalEntryOut)(ptr) },
+		_OP_NOTIFY_INVAL_INODE: func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalInodeOut)(ptr) },
+		_OP_NOTIFY_STORE_CACHE: func(ptr unsafe.Pointer) interface{} { return (*NotifyStoreOut)(ptr) },
+		_OP_NOTIFY_DELETE:      func(ptr unsafe.Pointer) interface{} { return (*NotifyInvalDeleteOut)(ptr) },
+		_OP_STATFS:             func(ptr unsafe.Pointer) interface{} { return (*StatfsOut)(ptr) },
+		_OP_SYMLINK:            func(ptr unsafe.Pointer) interface{} { return (*EntryOut)(ptr) },
+		_OP_GETLK:              func(ptr unsafe.Pointer) interface{} { return (*LkOut)(ptr) },
 	} {
 		operationHandlers[op].DecodeOut = f
 	}

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -454,9 +454,9 @@ func (ms *Server) InodeNotify(node uint64, off int64, length int64) Status {
 
 	req := request{
 		inHeader: &InHeader{
-			Opcode: _OP_NOTIFY_INODE,
+			Opcode: _OP_NOTIFY_INVAL_INODE,
 		},
-		handler: operationHandlers[_OP_NOTIFY_INODE],
+		handler: operationHandlers[_OP_NOTIFY_INVAL_INODE],
 		status:  NOTIFY_INVAL_INODE,
 	}
 
@@ -481,7 +481,7 @@ func (ms *Server) InodeNotify(node uint64, off int64, length int64) Status {
 // This call is similar to InodeNotify, but instead of only invalidating a data
 // region, it gives updated data directly to the kernel.
 func (ms *Server) InodeNotifyStoreCache(node uint64, offset int64, data []byte) Status {
-	if !ms.kernelSettings.SupportsNotify(NOTIFY_STORE) {
+	if !ms.kernelSettings.SupportsNotify(NOTIFY_STORE_CACHE) {
 		return ENOSYS
 	}
 
@@ -511,10 +511,10 @@ func (ms *Server) InodeNotifyStoreCache(node uint64, offset int64, data []byte) 
 func (ms *Server) inodeNotifyStoreCache32(node uint64, offset int64, data []byte) Status {
 	req := request{
 		inHeader: &InHeader{
-			Opcode: _OP_NOTIFY_STORE,
+			Opcode: _OP_NOTIFY_STORE_CACHE,
 		},
-		handler: operationHandlers[_OP_NOTIFY_STORE],
-		status:  NOTIFY_STORE,
+		handler: operationHandlers[_OP_NOTIFY_STORE_CACHE],
+		status:  NOTIFY_STORE_CACHE,
 	}
 
 	store := (*NotifyStoreOut)(req.outData())
@@ -550,7 +550,7 @@ func (ms *Server) DeleteNotify(parent uint64, child uint64, name string) Status 
 			Opcode: _OP_NOTIFY_DELETE,
 		},
 		handler: operationHandlers[_OP_NOTIFY_DELETE],
-		status:  NOTIFY_INVAL_DELETE,
+		status:  NOTIFY_DELETE,
 	}
 
 	entry := (*NotifyInvalDeleteOut)(req.outData())
@@ -585,9 +585,9 @@ func (ms *Server) EntryNotify(parent uint64, name string) Status {
 	}
 	req := request{
 		inHeader: &InHeader{
-			Opcode: _OP_NOTIFY_ENTRY,
+			Opcode: _OP_NOTIFY_INVAL_ENTRY,
 		},
-		handler: operationHandlers[_OP_NOTIFY_ENTRY],
+		handler: operationHandlers[_OP_NOTIFY_INVAL_ENTRY],
 		status:  NOTIFY_INVAL_ENTRY,
 	}
 	entry := (*NotifyInvalEntryOut)(req.outData())
@@ -619,16 +619,16 @@ func (in *InitIn) SupportsVersion(maj, min uint32) bool {
 }
 
 // SupportsNotify returns whether a certain notification type is
-// supported. Pass any of the NOTIFY_INVAL_* types as argument.
+// supported. Pass any of the NOTIFY_* types as argument.
 func (in *InitIn) SupportsNotify(notifyType int) bool {
 	switch notifyType {
 	case NOTIFY_INVAL_ENTRY:
 		return in.SupportsVersion(7, 12)
 	case NOTIFY_INVAL_INODE:
 		return in.SupportsVersion(7, 12)
-	case NOTIFY_STORE:
+	case NOTIFY_STORE_CACHE:
 		return in.SupportsVersion(7, 15)
-	case NOTIFY_INVAL_DELETE:
+	case NOTIFY_DELETE:
 		return in.SupportsVersion(7, 18)
 	}
 	return false

--- a/fuse/types.go
+++ b/fuse/types.go
@@ -384,12 +384,12 @@ type NotifyStoreOut struct {
 }
 
 const (
-	//	NOTIFY_POLL         = -1
-	NOTIFY_INVAL_INODE = -2
-	NOTIFY_INVAL_ENTRY = -3
-	NOTIFY_STORE       = -4
-	//	NOTIFY_RETRIEVE     = -5
-	NOTIFY_INVAL_DELETE = -6
+	//	NOTIFY_POLL         = -1 // notify kernel that a poll waiting for IO on a file handle should wake up
+	NOTIFY_INVAL_INODE = -2 // notify kernel that an inode should be invalidated
+	NOTIFY_INVAL_ENTRY = -3 // notify kernel that a directory entry should be invalidated
+	NOTIFY_STORE_CACHE = -4 // store data into kernel cache of an inode
+	//	NOTIFY_RETRIEVE_CACHE  = -5 // retrieve data from kernel cache of an inode
+	NOTIFY_DELETE      = -6 // notify kernel that a directory entry has been deleted
 
 //	NOTIFY_CODE_MAX     = -6
 )


### PR DESCRIPTION
- it is not NOTIFY_INVAL_DELETE, but just NOTIFY_DELETE as the kernel is
  notified of entry being deleted and there is no invalidation here.
  uapi/linux/fuse.h does not use "_INVAL_" for NOTIFY_DELETE neither.

- similarly for "notify store/retrieve" _INVAL_ is not appropriate and
  neither is used in uapi/linux/fuse.h . However since we took more
  explicit approach for "notify store/retrieve" naming (see bdca0e6a
  "Add support for store notify") let's also add _CACHE suffix for
  "notify store/retrieve" operation names for consistency and for being
  less ambiguous.

- for inode/entry invalidation operations, let's use _INVAL_ in internal
  _OP_NOTIFY_*, similarly to how it is used in corresponding NOTIFY_*
  constant. For example:

	_OP_NOTIFY_ENTRY -> _OP_NOTIFY_INVAL_ENTRY	(corresponds to NOTIFY_INVAL_ENTRY)