### PR TITLE
added syscall.EISDIR constant

### DIFF
--- a/fuse/types.go
+++ b/fuse/types.go
@@ -46,6 +46,9 @@ const (
 	// ENOTDIR Not a directory
 	ENOTDIR = Status(syscall.ENOTDIR)
 
+	// EISDIR Is a directory
+	EISDIR = Status(syscall.EISDIR)
+
 	// EPERM Operation not permitted
 	EPERM = Status(syscall.EPERM)
 


### PR DESCRIPTION
for convenience reasons like return values of `fuse.Status` in type FileSystem

e.g. in `Open(name string, flags uint32, context *fuse.Context) (file nodefs.File, code fuse.Status)`