### PR TITLE
Add support to retrieve kernel cache (retrieve notify)

### DIFF
--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -393,6 +393,9 @@ func (c *FileSystemConnector) FileNotify(node *Inode, off int64, length int64) f
 // and will use data from that cache for non direct-IO reads from the inode
 // in corresponding data region. After kernel's cache data is evicted, the kernel
 // will have to issue new Read calls on user request to get data content.
+//
+// ENOENT is returned if the kernel does not currently have entry for this
+// inode in its dentry cache.
 func (c *FileSystemConnector) FileNotifyStoreCache(node *Inode, off int64, data []byte) fuse.Status {
 	var nID uint64
 	if node == c.rootNode {
@@ -402,7 +405,8 @@ func (c *FileSystemConnector) FileNotifyStoreCache(node *Inode, off int64, data 
 	}
 
 	if nID == 0 {
-		return fuse.EINVAL
+		// the kernel does not currently know about this inode.
+		return fuse.ENOENT
 	}
 	return c.server.InodeNotifyStoreCache(nID, off, data)
 }

--- a/fuse/print.go
+++ b/fuse/print.go
@@ -236,6 +236,14 @@ func (o *NotifyStoreOut) string() string {
 	return fmt.Sprintf("{nodeid %d off %d sz %d}", o.Nodeid, o.Offset, o.Size)
 }
 
+func (o *NotifyRetrieveOut) string() string {
+	return fmt.Sprintf("{notifyUnique %d nodeid %d off %d sz %d}", o.NotifyUnique, o.Nodeid, o.Offset, o.Size)
+}
+
+func (i *NotifyRetrieveIn) string() string {
+	return fmt.Sprintf("{off %d sz %d}", i.Offset, i.Size)
+}
+
 func (f *FallocateIn) string() string {
 	return fmt.Sprintf("{Fh %d off %d sz %d mod 0%o}",
 		f.Fh, f.Offset, f.Length, f.Mode)

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -565,6 +565,9 @@ func (ms *Server) inodeNotifyStoreCache32(node uint64, offset int64, data []byte
 // [offset:offset+len(dest)) and waits for corresponding reply. If kernel cache
 // has fewer consecutive data starting at offset, that fewer amount is returned.
 // In particular if inode data at offset is not cached (0, OK) is returned.
+//
+// The kernel returns ENOENT if it does not currently have entry for this inode
+// in its dentry cache.
 func (ms *Server) InodeRetrieveCache(node uint64, offset int64, dest []byte) (n int, st Status) {
 	if !ms.kernelSettings.SupportsNotify(NOTIFY_RETRIEVE_CACHE) {
 		return 0, ENOSYS

--- a/fuse/test/cachecontrol_test.go
+++ b/fuse/test/cachecontrol_test.go
@@ -122,8 +122,12 @@ func TestCacheControl(t *testing.T) {
 	}
 
 	// before the kernel has entry for file in its dentry cache, the cache
-	// should read as empty.
+	// should read as empty and cache store should fail with ENOENT.
 	assertCacheRead("before lookup", "")
+	st := fsconn.FileNotifyStoreCache(file.Inode(), 0, []byte("abc"))
+	if st != fuse.ENOENT {
+		t.Fatalf("%s: store cache -> %v; want %v", "before lookup", st, fuse.ENOENT)
+	}
 
 	// lookup on the file - forces to assign inode ID to it
 	os.Stat(dir + "/hello.txt")
@@ -171,7 +175,7 @@ func TestCacheControl(t *testing.T) {
 	assertCacheRead("original", data0)
 
 	// store changed data into OS cache
-	st := fsconn.FileNotifyStoreCache(file.Inode(), 7, []byte("123"))
+	st = fsconn.FileNotifyStoreCache(file.Inode(), 7, []byte("123"))
 	if st != fuse.OK {
 		t.Fatalf("store cache: %s", st)
 	}

--- a/fuse/types.go
+++ b/fuse/types.go
@@ -386,13 +386,31 @@ type NotifyStoreOut struct {
 	Padding uint32
 }
 
+type NotifyRetrieveOut struct {
+	NotifyUnique uint64
+	Nodeid       uint64
+	Offset       uint64
+	Size         uint32
+	Padding      uint32
+}
+
+type NotifyRetrieveIn struct {
+	InHeader
+	Dummy1 uint64
+	Offset uint64
+	Size   uint32
+	Dummy2 uint32
+	Dummy3 uint64
+	Dummy4 uint64
+}
+
 const (
 	//	NOTIFY_POLL         = -1 // notify kernel that a poll waiting for IO on a file handle should wake up
-	NOTIFY_INVAL_INODE = -2 // notify kernel that an inode should be invalidated
-	NOTIFY_INVAL_ENTRY = -3 // notify kernel that a directory entry should be invalidated
-	NOTIFY_STORE_CACHE = -4 // store data into kernel cache of an inode
-	//	NOTIFY_RETRIEVE_CACHE  = -5 // retrieve data from kernel cache of an inode
-	NOTIFY_DELETE = -6 // notify kernel that a directory entry has been deleted
+	NOTIFY_INVAL_INODE    = -2 // notify kernel that an inode should be invalidated
+	NOTIFY_INVAL_ENTRY    = -3 // notify kernel that a directory entry should be invalidated
+	NOTIFY_STORE_CACHE    = -4 // store data into kernel cache of an inode
+	NOTIFY_RETRIEVE_CACHE = -5 // retrieve data from kernel cache of an inode
+	NOTIFY_DELETE         = -6 // notify kernel that a directory entry has been deleted
 
 //	NOTIFY_CODE_MAX     = -6
 )


### PR DESCRIPTION
This patch continues bdca0e6a (Add support for store notify) and adds
corresponding support for counterpart to cache-store - to retrieve an inode
data from kernel cache.

As it was already noted in bdca0e6a, FUSE protocol provides primitives for
pagecache control: to invalidate a data region for inode (notify_inval_inode),
to store data into inode kernel's cache (notify_store), and to retrieve data
from inode kernel's cache (notify_retrieve). For the latter 2 FUSE protocol
messages and brief documentation about semantic can be seen here:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fuse.h?id=v4.19-rc6-177-gcec4de302c5f#n68
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fuse.h?id=v4.19-rc6-177-gcec4de302c5f#n756

https://git.kernel.org/linus/a1d75f2582
https://git.kernel.org/linus/2d45ba381a

In short, to retrieve data from kernel cache, filesystem server sends

	S > C	NOTIFY_RETRIEVE_CACHE{notifyUnique, inode, offset, size}

and if that message was sent correctly, the kernel sends back another
write-style message with unique=notifyUnique

	S < C	NOTIFY_REPLY{inode, offset, size, data}

Since so far there were no cases when a server was querying the kernel,
and the reply comes as separate kernel "request", we have to add
infrastructure for tracking such in-flight queries. This is done by
adding Server.retrieveTab and friends.

Otherwise the implementation is straightforward.

A particular note is that from a user-level API point of view we are not
following e.g. libfuse to register a callback to be invoked upon reply, but
instead provide {Inode,File}RetrieveCache that synchronously send notify query
and wait for kernel's reply.

This fits more naturally to Go and is easier to use.