### PR TITLE
added EREMOTEIO constant

### DIFF
--- a/fuse/types.go
+++ b/fuse/types.go
@@ -34,6 +34,9 @@ const (
 	// EIO I/O error
 	EIO = Status(syscall.EIO)
 
+	// EREMOTEIO Remote I/O error
+	EREMOTEIO = Status(syscall.EREMOTEIO)
+
 	// ENOENT No such file or directory
 	ENOENT = Status(syscall.ENOENT)
 


### PR DESCRIPTION
my fuse implementation connects to another backend. I want users to be able to tell, whether a IO error happens on my fuse implementation itself (because users did some wrong interaction or sth. else) or rather on the backend (because backend itself returns an EIO error, which would be wrongy interpreted if my implementation returned EIO as well).

It's not a MUST, I could still live with the EIO option. But would be very nice.