### PR TITLE
Revert "added EREMOTEIO constant"

### DIFF
--- a/fuse/types.go
+++ b/fuse/types.go
@@ -34,9 +34,6 @@ const (
 	// EIO I/O error
 	EIO = Status(syscall.EIO)
 
-	// EREMOTEIO Remote I/O error
-	EREMOTEIO = Status(syscall.EREMOTEIO)
-
 	// ENOENT No such file or directory
 	ENOENT = Status(syscall.ENOENT)
 


### PR DESCRIPTION
Reverts hanwen/go-fuse#247

As mentioned by @rfjakob in #247 , EREMOTEIO is unknown on macOS.

_I will, as mentioned by @navytux in #247 , implement the error code in my own code. Thanks for the hint!_