### PR TITLE
fuse: ↑ signal/noise in log messages

### DIFF
--- a/fuse/print.go
+++ b/fuse/print.go
@@ -198,19 +198,24 @@ func (me *FlushIn) string() string {
 
 func (me *AttrOut) string() string {
 	return fmt.Sprintf(
-		"{A%d.%09d %v}",
-		me.AttrValid, me.AttrValidNsec, &me.Attr)
+		"{tA=%gs %v}",
+		ft(me.AttrValid, me.AttrValidNsec), &me.Attr)
+}
+
+// ft converts (seconds , nanoseconds) -> float(seconds)
+func ft(tsec uint64, tnsec uint32) float64 {
+	return float64(tsec) + float64(tnsec)*1E-9
 }
 
 // Returned by LOOKUP
 func (me *EntryOut) string() string {
-	return fmt.Sprintf("{NodeId: %d Generation=%d EntryValid=%d.%03d AttrValid=%d.%03d Attr=%v}",
-		me.NodeId, me.Generation, me.EntryValid, me.EntryValidNsec/1000000,
-		me.AttrValid, me.AttrValidNsec/1000000, &me.Attr)
+	return fmt.Sprintf("{i%d g%d tE=%gs tA=%gs %v}",
+		me.NodeId, me.Generation, ft(me.EntryValid, me.EntryValidNsec),
+		ft(me.AttrValid, me.AttrValidNsec), &me.Attr)
 }
 
 func (me *CreateOut) string() string {
-	return fmt.Sprintf("{NodeId: %d Generation=%d %v %v}", me.NodeId, me.Generation, &me.EntryOut, &me.OpenOut)
+	return fmt.Sprintf("{i%d g%d %v %v}", me.NodeId, me.Generation, &me.EntryOut, &me.OpenOut)
 }
 
 func (me *StatfsOut) string() string {
@@ -225,7 +230,7 @@ func (o *NotifyInvalEntryOut) string() string {
 }
 
 func (o *NotifyInvalInodeOut) string() string {
-	return fmt.Sprintf("{ino %d off %d sz %d}", o.Ino, o.Off, o.Length)
+	return fmt.Sprintf("{i%d [%d +%d)}", o.Ino, o.Off, o.Length)
 }
 
 func (o *NotifyInvalDeleteOut) string() string {
@@ -233,19 +238,19 @@ func (o *NotifyInvalDeleteOut) string() string {
 }
 
 func (o *NotifyStoreOut) string() string {
-	return fmt.Sprintf("{nodeid %d off %d sz %d}", o.Nodeid, o.Offset, o.Size)
+	return fmt.Sprintf("{i%d [%d +%d)}", o.Nodeid, o.Offset, o.Size)
 }
 
 func (o *NotifyRetrieveOut) string() string {
-	return fmt.Sprintf("{notifyUnique %d nodeid %d off %d sz %d}", o.NotifyUnique, o.Nodeid, o.Offset, o.Size)
+	return fmt.Sprintf("{> %d: i%d [%d +%d)}", o.NotifyUnique, o.Nodeid, o.Offset, o.Size)
 }
 
 func (i *NotifyRetrieveIn) string() string {
-	return fmt.Sprintf("{off %d sz %d}", i.Offset, i.Size)
+	return fmt.Sprintf("{[%d +%d)}", i.Offset, i.Size)
 }
 
 func (f *FallocateIn) string() string {
-	return fmt.Sprintf("{Fh %d off %d sz %d mod 0%o}",
+	return fmt.Sprintf("{Fh %d [%d +%d) mod 0%o}",
 		f.Fh, f.Offset, f.Length, f.Mode)
 }
 

--- a/fuse/print_darwin.go
+++ b/fuse/print_darwin.go
@@ -19,14 +19,14 @@ func (a *Attr) string() string {
 		"{M0%o SZ=%d L=%d "+
 			"%d:%d "+
 			"%d %d:%d "+
-			"A %d.%09d "+
-			"M %d.%09d "+
-			"C %d.%09d}",
+			"A %f "+
+			"M %f "+
+			"C %f}",
 		a.Mode, a.Size, a.Nlink,
 		a.Uid, a.Gid,
 		a.Blocks,
-		a.Rdev, a.Ino, a.Atime, a.Atimensec, a.Mtime, a.Mtimensec,
-		a.Ctime, a.Ctimensec)
+		a.Rdev, a.Ino, ft(a.Atime, a.Atimensec), ft(a.Mtime, a.Mtimensec),
+		ft(a.Ctime, a.Ctimensec))
 }
 
 func (me *CreateIn) string() string {
@@ -42,13 +42,13 @@ func (me *MknodIn) string() string {
 }
 
 func (me *ReadIn) string() string {
-	return fmt.Sprintf("{Fh %d off %d sz %d %s}",
+	return fmt.Sprintf("{Fh %d [%d +%d) %s}",
 		me.Fh, me.Offset, me.Size,
 		FlagString(readFlagNames, int64(me.ReadFlags), ""))
 }
 
 func (me *WriteIn) string() string {
-	return fmt.Sprintf("{Fh %d off %d sz %d %s}",
+	return fmt.Sprintf("{Fh %d [%d +%d) %s}",
 		me.Fh, me.Offset, me.Size,
 		FlagString(writeFlagNames, int64(me.WriteFlags), ""))
 }

--- a/fuse/print_linux.go
+++ b/fuse/print_linux.go
@@ -21,14 +21,14 @@ func (a *Attr) string() string {
 		"{M0%o SZ=%d L=%d "+
 			"%d:%d "+
 			"B%d*%d i%d:%d "+
-			"A %d.%09d "+
-			"M %d.%09d "+
-			"C %d.%09d}",
+			"A %f "+
+			"M %f "+
+			"C %f}",
 		a.Mode, a.Size, a.Nlink,
 		a.Uid, a.Gid,
 		a.Blocks, a.Blksize,
-		a.Rdev, a.Ino, a.Atime, a.Atimensec, a.Mtime, a.Mtimensec,
-		a.Ctime, a.Ctimensec)
+		a.Rdev, a.Ino, ft(a.Atime, a.Atimensec), ft(a.Mtime, a.Mtimensec),
+		ft(a.Ctime, a.Ctimensec))
 }
 
 func (me *CreateIn) string() string {
@@ -46,7 +46,7 @@ func (me *MknodIn) string() string {
 }
 
 func (me *ReadIn) string() string {
-	return fmt.Sprintf("{Fh %d off %d sz %d %s L %d %s}",
+	return fmt.Sprintf("{Fh %d [%d +%d) %s L %d %s}",
 		me.Fh, me.Offset, me.Size,
 		FlagString(readFlagNames, int64(me.ReadFlags), ""),
 		me.LockOwner,
@@ -54,7 +54,7 @@ func (me *ReadIn) string() string {
 }
 
 func (me *WriteIn) string() string {
-	return fmt.Sprintf("{Fh %d off %d sz %d %s L %d %s}",
+	return fmt.Sprintf("{Fh %d [%d +%d) %s L %d %s}",
 		me.Fh, me.Offset, me.Size,
 		FlagString(writeFlagNames, int64(me.WriteFlags), ""),
 		me.LockOwner,


### PR DESCRIPTION
- use tA=...s instead of `A...` or `AttrValid=...` for time(Attr valid);
- use tE=...s instead of `EntryValid` for time(Entry valid);
- use iX instead of `NodeId: X` for inode X;
- use gX instead of `Generation=X` for generation X;
- use `[<off> +<size>)` instead of `off <off> sz <sz>`;

- use

	< uniq: iX.Op opargs
	> uniq: status reply...

  instead of

	Dispatch uniq: Op NodeId: X opargs
	Serialize uniq: Op code: status reply...

  for received/replied messages;

- use `["file1", "file2"]` instead of `names: [file1, file2]` for filenames.

- use `xb` instead of `x bytes`

- for replied data, also log data content, but only up to first 8 bytes.
  This does not flood the log, but at the same time makes filesystem
  diagnostics easier.

  If this last change is controversial, it could be dropped from the
  patch.

Overall effect. Please compare how it was before:

	wcfs: 17:09:21.910510 Dispatch 1: INIT, NodeId: 0. data: {7.27 Ra 0x20000 ASYNC_READ,SPLICE_WRITE,FLOCK_LOCKS,IOCTL_DIR,READDIRPLUS_AUTO,ASYNC_DIO,CAP_POSIX_ACL,POSIX_LOCKS,DONT_MASK,SPLICE_MOVE,AUTO_INVAL_DATA,CAP_PARALLEL_DIROPS,ATOMIC_O_TRUNC,SPLICE_READ,NO_OPEN_SUPPORT,CAP_PARALLEL_DIROPS,EXPORT_SUPPORT,BIG_WRITES,READDIRPLUS,WRITEBACK_CACHE,0x200000}
	wcfs: 17:09:21.911719 Serialize 1: INIT code: OK value: {7.23 Ra 0x20000 NO_OPEN_SUPPORT,BIG_WRITES,READDIRPLUS,ASYNC_READ,AUTO_INVAL_DATA 0/0 Wr 0x10000 Tg 0x0}
	wcfs: 17:09:22.002776 Dispatch 2: LOOKUP, NodeId: 1. names: [.wcfs] 6 bytes
	wcfs: 17:09:22.002881 Serialize 2: LOOKUP code: OK value: {NodeId: 3 Generation=2 EntryValid=1.000 AttrValid=1.000 Attr={M0100644 SZ=33 L=1 1000:1000 B0*0 i0:3 A 0.000000000 M 0.000000000 C 0.000000000}}
	wcfs: 17:09:22.003022 Dispatch 3: OPEN, NodeId: 3. data: {O_RDONLY,0x8000}
	wcfs: 17:09:22.003064 Serialize 3: OPEN code: 38=function not implemented value: {Fh 0 }
	wcfs: 17:09:22.003213 Dispatch 4: READ, NodeId: 3. data: {Fh 0 off 0 sz 4096  L 0 RDONLY,0x8000}
	wcfs: 17:09:22.003261 Serialize 4: READ code: OK value:  33 bytes data
	wcfs: 17:09:22.003330 Dispatch 5: GETATTR, NodeId: 3. data: {Fh 0}
	wcfs: 17:09:22.003375 Serialize 5: GETATTR code: OK value: {A1.000000000 {M0100644 SZ=33 L=1 1000:1000 B0*0 i0:3 A 0.000000000 M 0.000000000 C 0.000000000}}
	wcfs: 17:09:22.004102 Dispatch 6: FLUSH, NodeId: 3. data: {Fh 0}
	wcfs: 17:09:22.004130 Serialize 6: FLUSH code: OK value:
	wcfs: 17:09:22.004278 Dispatch 7: LOOKUP, NodeId: 1. names: [bigfile] 8 bytes
	wcfs: 17:09:22.004320 Serialize 7: LOOKUP code: OK value: {NodeId: 4 Generation=3 EntryValid=1.000 AttrValid=1.000 Attr={M040755 SZ=0 L=0 1000:1000 B0*0 i0:4 A 0.000000000 M 0.000000000 C 0.000000000}}
	wcfs: 17:09:22.004448 Dispatch 8: FLUSH, NodeId: 3. data: {Fh 0}
	wcfs: 17:09:22.004465 Serialize 8: FLUSH code: OK value:
	wcfs: 17:09:22.019004 Dispatch 9: GETATTR, NodeId: 1. data: {Fh 0}
	wcfs: 17:09:22.019055 Serialize 9: GETATTR code: OK value: {A1.000000000 {M040755 SZ=0 L=1 1000:1000 B0*0 i0:1 A 0.000000000 M 0.000000000 C 0.000000000}}

to how it is after the patch:

	wcfs: 17:06:23.871173 < 1: i0.INIT {7.27 Ra 0x20000 BIG_WRITES,DONT_MASK,SPLICE_READ,READDIRPLUS,CAP_PARALLEL_DIROPS,CAP_PARALLEL_DIROPS,WRITEBACK_CACHE,ASYNC_READ,ATOMIC_O_TRUNC,SPLICE_WRITE,SPLICE_MOVE,FLOCK_LOCKS,READDIRPLUS_AUTO,ASYNC_DIO,NO_OPEN_SUPPORT,POSIX_LOCKS,IOCTL_DIR,AUTO_INVAL_DATA,CAP_POSIX_ACL,EXPORT_SUPPORT,0x200000}
	wcfs: 17:06:23.871220 > 1:     OK, {7.23 Ra 0x20000 ASYNC_READ,NO_OPEN_SUPPORT,AUTO_INVAL_DATA,BIG_WRITES,READDIRPLUS 0/0 Wr 0x10000 Tg 0x0}
	wcfs: 17:06:23.966413 < 2: i1.LOOKUP [".wcfs"] 6b
	wcfs: 17:06:23.966514 > 2:     OK, {i3 g2 tE=1s tA=1s {M0100644 SZ=33 L=1 1000:1000 B0*0 i0:3 A 0.000000 M 0.000000 C 0.000000}}
	wcfs: 17:06:23.967245 < 3: i3.OPEN {O_RDONLY,0x8000}
	wcfs: 17:06:23.967321 > 3:     38=function not implemented, {Fh 0 }
	wcfs: 17:06:23.967504 < 4: i3.READ {Fh 0 [0 +4096)  L 0 RDONLY,0x8000}
	wcfs: 17:06:23.967579 > 4:     OK,  33b data "file:///"...
	wcfs: 17:06:23.967676 < 5: i3.GETATTR {Fh 0}
	wcfs: 17:06:23.967802 > 5:     OK, {tA=1s {M0100644 SZ=33 L=1 1000:1000 B0*0 i0:3 A 0.000000 M 0.000000 C 0.000000}}
	wcfs: 17:06:23.969071 < 6: i3.FLUSH {Fh 0}
	wcfs: 17:06:23.969109 > 6:     OK
	wcfs: 17:06:23.969749 < 7: i1.LOOKUP ["bigfile"] 8b
	wcfs: 17:06:23.969818 > 7:     OK, {i4 g3 tE=1s tA=1s {M040755 SZ=0 L=0 1000:1000 B0*0 i0:4 A 0.000000 M 0.000000 C 0.000000}}
	wcfs: 17:06:23.970053 < 8: i3.FLUSH {Fh 0}
	wcfs: 17:06:23.970085 > 8:     OK
	wcfs: 17:06:23.984087 < 9: i1.GETATTR {Fh 0}
	wcfs: 17:06:23.984146 > 9:     OK, {tA=1s {M040755 SZ=0 L=1 1000:1000 B0*0 i0:1 A 0.000000 M 0.000000 C 0.000000}}