### PR TITLE
readme: Add appendix about how to read Go-FUSE debug log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,45 @@ Grep source code for TODO.  Major topics:
 
 Like Go, this library is distributed under the new BSD license.  See
 accompanying LICENSE file.
+
+--------
+
+## Appendix I. Go-FUSE log format
+
+To increase signal/noise ratio Go-FUSE uses abbreviations in its debug log
+output. Here is how to read it:
+
+- `iX` means `inode X`;
+- `gX` means `generation X`;
+- `tA` and `tE` means timeout for attributes and directory entry correspondingly;
+- `[<off> +<size>)` means data range from `<off>` inclusive till `<off>+<size>` exclusive;
+- `Xb` means `X bytes`.
+
+Every line is prefixed with either `rx <unique>` or `tx <unique>` to denote
+whether it was for kernel request, which Go-FUSE received, or reply, which
+Go-FUSE sent back to kernel.
+
+Example debug log output:
+
+```
+rx 2: LOOKUP i1 [".wcfs"] 6b
+tx 2:     OK, {i3 g2 tE=1s tA=1s {M040755 SZ=0 L=0 1000:1000 B0*0 i0:3 A 0.000000 M 0.000000 C 0.000000}}
+rx 3: LOOKUP i3 ["zurl"] 5b
+tx 3:     OK, {i4 g3 tE=1s tA=1s {M0100644 SZ=33 L=1 1000:1000 B0*0 i0:4 A 0.000000 M 0.000000 C 0.000000}}
+rx 4: OPEN i4 {O_RDONLY,0x8000}
+tx 4:     38=function not implemented, {Fh 0 }
+rx 5: READ i4 {Fh 0 [0 +4096)  L 0 RDONLY,0x8000}
+tx 5:     OK,  33b data "file:///"...
+rx 6: GETATTR i4 {Fh 0}
+tx 6:     OK, {tA=1s {M0100644 SZ=33 L=1 1000:1000 B0*0 i0:4 A 0.000000 M 0.000000 C 0.000000}}
+rx 7: FLUSH i4 {Fh 0}
+tx 7:     OK
+rx 8: LOOKUP i1 ["head"] 5b
+tx 8:     OK, {i5 g4 tE=1s tA=1s {M040755 SZ=0 L=0 1000:1000 B0*0 i0:5 A 0.000000 M 0.000000 C 0.000000}}
+rx 9: LOOKUP i5 ["bigfile"] 8b
+tx 9:     OK, {i6 g5 tE=1s tA=1s {M040755 SZ=0 L=0 1000:1000 B0*0 i0:6 A 0.000000 M 0.000000 C 0.000000}}
+rx 10: FLUSH i4 {Fh 0}
+tx 10:     OK
+rx 11: GETATTR i1 {Fh 0}
+tx 11:     OK, {tA=1s {M040755 SZ=0 L=1 1000:1000 B0*0 i0:1 A 0.000000 M 0.000000 C 0.000000}}
+```


### PR DESCRIPTION
d1c826d1 ("fuse: increase signal/noise in log messages",
https://github.com/hanwen/go-fuse/pull/249) changed log to use
abbreviations in the name of improving signal/noise ratio. However it
might be not evident offhand what an abbreviation means.

Add a short reference in the readme with the summary on how to read the
log and a short example.

The summary is incomplete - for example I don't describe Fh and other
attributes that d1c826d1 did not change. I propose we review logging
more, e.g. consider doing `Fh X` -> `fX` and maybe similarly for other
fields, and while doing so, also populate/update the summary and example
in the readme. In other words it is good to document current state, but
it is not fixed in stone and can be evolved.