### PR TITLE
server: print debug message on ENODEV

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -388,6 +388,9 @@ exit:
 			continue
 		case ENODEV:
 			// unmount
+			if ms.opts.Debug {
+				log.Printf("received ENODEV (unmount request), thread exiting")
+			}
 			break exit
 		default: // some other error?
 			log.Printf("Failed to read from fuse conn: %v", errNo)


### PR DESCRIPTION
This makes it clear when (and why) the filesystem was unmounted.

Example output:
```
$ gocryptfs -fg -nosyslog -fusedebug a b
Password:
Decrypting master key
Filesystem mounted and ready.
2019/01/23 21:52:59 rx 2: ACCESS i1 {r}
2019/01/23 21:52:59 tx 2:     OK
2019/01/23 21:52:59 rx 3: LOOKUP i1 [".Trash"] 7b
2019/01/23 21:52:59 tx 3:     OK, {i0 g0 tE=1s tA=0s {M00 SZ=0 L=0 0:0 B0*0 i0:0 A 0.000000 M 0.000000 C 0.000000}}
2019/01/23 21:52:59 rx 4: LOOKUP i1 [".Trash-1026"] 12b
2019/01/23 21:52:59 tx 4:     OK, {i0 g0 tE=1s tA=0s {M00 SZ=0 L=0 0:0 B0*0 i0:0 A 0.000000 M 0.000000 C 0.000000}}
2019/01/23 21:53:02 received ENODEV (unmount request), thread exiting
2019/01/23 21:53:02 received ENODEV (unmount request), thread exiting
2019/01/23 21:53:02 received ENODEV (unmount request), thread exiting
```