### PR TITLE
Prevent rename() spuriously returning ENOENT.

### DIFF
--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -319,11 +319,7 @@ func (c *rawBridge) Symlink(header *fuse.InHeader, pointedTo string, linkName st
 func (c *rawBridge) Rename(input *fuse.RenameIn, oldName string, newName string) (code fuse.Status) {
 	oldParent := c.toInode(input.NodeId)
 
-	child := oldParent.GetChild(oldName)
-	if child == nil {
-		return fuse.ENOENT
-	}
-	if child.mountPoint != nil {
+	if child := oldParent.GetChild(oldName); child != nil && child.mountPoint != nil {
 		return fuse.EBUSY
 	}
 

--- a/fuse/test/rename_unresolved_file_test.go
+++ b/fuse/test/rename_unresolved_file_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019 the Go-FUSE Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
+)
+
+type noopFile struct {
+	nodefs.Node
+}
+
+func (f *noopFile) GetAttr(out *fuse.Attr, file nodefs.File, conetext *fuse.Context) fuse.Status {
+	out.Mode = fuse.S_IFREG | 0777
+	out.Size = 123
+	return fuse.OK
+}
+
+type singleFileDirectory struct {
+	nodefs.Node
+	currentFilename string
+	childNode       nodefs.Node
+}
+
+func (d *singleFileDirectory) Open(flags uint32, context *fuse.Context) (nodefs.File, fuse.Status) {
+	return nil, fuse.OK
+}
+
+func (d *singleFileDirectory) Lookup(out *fuse.Attr, name string, context *fuse.Context) (*nodefs.Inode, fuse.Status) {
+	if name != d.currentFilename {
+		return nil, fuse.ENOENT
+	}
+	d.childNode.GetAttr(out, nil, context)
+	return d.Inode().NewChild(name, false, d.childNode), fuse.OK
+}
+
+func (d *singleFileDirectory) Rename(oldName string, newParent nodefs.Node, newName string, context *fuse.Context) fuse.Status {
+	if d != newParent {
+		return fuse.EXDEV
+	}
+	if oldName != d.currentFilename {
+		return fuse.ENOENT
+	}
+	// Lazy implementation that doesn't bother re-adding the child
+	// under the new name. Another lookup should cause it to be
+	// accessible once again.
+	d.Inode().RmChild(oldName)
+	d.currentFilename = newName
+	return fuse.OK
+}
+
+// TestRenameUnresolvedFile renames a file in a directory a couple of
+// times in a row. The directory has been implemented in such a way that
+// it only removes the old name from the file system. A successive
+// lookup should be performed to access the file at the new location.
+func TestRenameUnresolvedFile(t *testing.T) {
+	dir := testutil.TempDir()
+	defer func() {
+		err := os.Remove(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	root := &singleFileDirectory{
+		Node:            nodefs.NewDefaultNode(),
+		currentFilename: "foo",
+		childNode: &noopFile{
+			Node: nodefs.NewDefaultNode(),
+		},
+	}
+	opts := nodefs.NewOptions()
+	opts.Debug = testutil.VerboseTest()
+	srv, _, err := nodefs.MountRoot(dir, root, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go srv.Serve()
+	if err := srv.WaitMount(); err != nil {
+		t.Fatal("WaitMount", err)
+	}
+	defer func() {
+		err := srv.Unmount()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := os.Rename(dir+"/foo", dir+"/bar"); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+	if err := os.Rename(dir+"/bar", dir+"/baz"); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+	if err := os.Rename(dir+"/baz", dir+"/qux"); err != nil {
+		t.Fatalf("rename: %s", err)
+	}
+}


### PR DESCRIPTION
I'm implementing a file system that does its own bookkeeping of files
stored in a directory. I need to do this, due to the file sytem also
being accessible without going through FUSE. At certain phases, it's
even the case the file system is only in-memory and not even exposed
through FUSE.

To keep things simple, I've made it so that upon renames and unlinks, I
only call into RmChild(). I rely ook Lookup() to expose files once again
afterwards. This approach currently causes me to observe some spurious
ENOENTs due to the EBUSY check for mount point renaming. Move both
checks into one, eliminating the ENOENT return.