### PR TITLE
Prevent concurrent LOOKUP and FORGET

### DIFF
--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -310,8 +310,7 @@ func (n *pathInode) GetPath() string {
 		// some file system operation, because the file is
 		// still opened.
 
-		// TODO - add a deterministic disambiguating suffix.
-		return ".deleted"
+		return ".deleted." + n.inode.String()
 	}
 
 	return path


### PR DESCRIPTION
Add a lock that prevents LOOKUP and FORGET from running concurrently.
    
Locking at this level is a big hammer, but makes sure we don't return
forgotten nodes to the kernel. Problems solved by this lock:
    
https://github.com/hanwen/go-fuse/issues/168
https://github.com/rfjakob/gocryptfs/issues/322
