### PR TITLE
nodefs: Drop unneecessary casts

### DIFF
--- a/fuse/nodefs/dir.go
+++ b/fuse/nodefs/dir.go
@@ -36,7 +36,7 @@ func (d *connectorDir) ReadDir(input *fuse.ReadIn, out *fuse.DirEntryList) (code
 	// rewinddir() should be as if reopening directory.
 	// TODO - test this.
 	if d.lastOffset > 0 && input.Offset == 0 {
-		d.stream, code = d.node.OpenDir((*fuse.Context)(&input.Context))
+		d.stream, code = d.node.OpenDir(&input.Context)
 		if !code.Ok() {
 			return code
 		}
@@ -72,7 +72,7 @@ func (d *connectorDir) ReadDirPlus(input *fuse.ReadIn, out *fuse.DirEntryList) (
 
 	// rewinddir() should be as if reopening directory.
 	if d.lastOffset > 0 && input.Offset == 0 {
-		d.stream, code = d.node.OpenDir((*fuse.Context)(&input.Context))
+		d.stream, code = d.node.OpenDir(&input.Context)
 		if !code.Ok() {
 			return code
 		}

--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -92,7 +92,7 @@ func (c *FileSystemConnector) verify() {
 
 // childLookup fills entry information for a newly created child inode
 func (c *rawBridge) childLookup(out *fuse.EntryOut, n *Inode, context *fuse.Context) {
-	n.Node().GetAttr((*fuse.Attr)(&out.Attr), nil, context)
+	n.Node().GetAttr(&out.Attr, nil, context)
 	n.mount.fillEntry(out)
 	out.NodeId, out.Generation = c.fsConn().lookupUpdate(n)
 	if out.Ino == 0 {

--- a/fuse/nodefs/fsmount.go
+++ b/fuse/nodefs/fsmount.go
@@ -59,7 +59,7 @@ func (m *fileSystemMount) mountName() string {
 
 func (m *fileSystemMount) setOwner(attr *fuse.Attr) {
 	if m.options.Owner != nil {
-		attr.Owner = *(*fuse.Owner)(m.options.Owner)
+		attr.Owner = *m.options.Owner
 	}
 }
 

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -134,7 +134,7 @@ func (c *rawBridge) GetAttr(input *fuse.GetAttrIn, out *fuse.AttrOut) (code fuse
 		}
 	}
 
-	dest := (*fuse.Attr)(&out.Attr)
+	dest := &out.Attr
 	code = node.fsInode.GetAttr(dest, f, &input.Context)
 	if !code.Ok() {
 		return code
@@ -253,7 +253,7 @@ func (c *rawBridge) SetAttr(input *fuse.SetAttrIn, out *fuse.AttrOut) (code fuse
 
 	// Must call GetAttr(); the filesystem may override some of
 	// the changes we effect here.
-	attr := (*fuse.Attr)(&out.Attr)
+	attr := &out.Attr
 	code = node.fsInode.GetAttr(attr, nil, &input.Context)
 	if code.Ok() {
 		node.mount.fillAttr(out, input.NodeId)
@@ -279,7 +279,7 @@ func (c *rawBridge) Mknod(input *fuse.MknodIn, name string, out *fuse.EntryOut) 
 	child, code := parent.fsInode.Mknod(name, input.Mode, uint32(input.Rdev), &input.Context)
 	if code.Ok() {
 		c.childLookup(out, child, &input.Context)
-		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
+		code = child.fsInode.GetAttr(&out.Attr, nil, &input.Context)
 	}
 	return code
 }
@@ -290,7 +290,7 @@ func (c *rawBridge) Mkdir(input *fuse.MkdirIn, name string, out *fuse.EntryOut) 
 	child, code := parent.fsInode.Mkdir(name, input.Mode, &input.Context)
 	if code.Ok() {
 		c.childLookup(out, child, &input.Context)
-		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
+		code = child.fsInode.GetAttr(&out.Attr, nil, &input.Context)
 	}
 	return code
 }
@@ -311,7 +311,7 @@ func (c *rawBridge) Symlink(header *fuse.InHeader, pointedTo string, linkName st
 	child, code := parent.fsInode.Symlink(linkName, pointedTo, &header.Context)
 	if code.Ok() {
 		c.childLookup(out, child, &header.Context)
-		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &header.Context)
+		code = child.fsInode.GetAttr(&out.Attr, nil, &header.Context)
 	}
 	return code
 }
@@ -346,7 +346,7 @@ func (c *rawBridge) Link(input *fuse.LinkIn, name string, out *fuse.EntryOut) (c
 	child, code := parent.fsInode.Link(name, existing.fsInode, &input.Context)
 	if code.Ok() {
 		c.childLookup(out, child, &input.Context)
-		code = child.fsInode.GetAttr((*fuse.Attr)(&out.Attr), nil, &input.Context)
+		code = child.fsInode.GetAttr(&out.Attr, nil, &input.Context)
 	}
 
 	return code


### PR DESCRIPTION
- casting fuse.AttrOut.Attr to fuse.Attr is noop
- casting fileSystemMount.options.Owner to fuse.Owner is noop
- casting fuse.ReadIn.Context to fuse.Context is noop