### PR TITLE
fuse: When parent or child is inode, log it as iX instead of X

### DIFF
--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -284,7 +284,7 @@ func (c *FileSystemConnector) lockMount(parent *Inode, name string, root Node, o
 
 	node.mountPoint.parentInode = parent
 	if c.debug {
-		log.Printf("Mount %T on subdir %s, parent %d", node,
+		log.Printf("Mount %T on subdir %s, parent i%d", node,
 			name, c.inodeMap.Handle(&parent.handled))
 	}
 	return node, fuse.OK

--- a/fuse/print.go
+++ b/fuse/print.go
@@ -226,7 +226,7 @@ func (me *StatfsOut) string() string {
 }
 
 func (o *NotifyInvalEntryOut) string() string {
-	return fmt.Sprintf("{parent %d sz %d}", o.Parent, o.NameLen)
+	return fmt.Sprintf("{parent i%d sz %d}", o.Parent, o.NameLen)
 }
 
 func (o *NotifyInvalInodeOut) string() string {
@@ -234,7 +234,7 @@ func (o *NotifyInvalInodeOut) string() string {
 }
 
 func (o *NotifyInvalDeleteOut) string() string {
-	return fmt.Sprintf("{parent %d ch %d sz %d}", o.Parent, o.Child, o.NameLen)
+	return fmt.Sprintf("{parent i%d ch i%d sz %d}", o.Parent, o.Child, o.NameLen)
 }
 
 func (o *NotifyStoreOut) string() string {


### PR DESCRIPTION
For example

	15:12:42.711011 tx 0: NOTIFY_INVAL_ENTRY, {parent i1 sz 8} "file.txt"

instead of

	15:12:42.711011 tx 0: NOTIFY_INVAL_ENTRY, {parent 1 sz 8} "file.txt"

using iX fits into our general logging scheme and makes logs more
self-descriptive.