### PR TITLE
fuse: Enable parallel lookup and readdir by default

### DIFF
--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -85,7 +85,7 @@ func doInit(server *Server, req *request) {
 	server.reqMu.Lock()
 	server.kernelSettings = *input
 	server.kernelSettings.Flags = input.Flags & (CAP_ASYNC_READ | CAP_BIG_WRITES | CAP_FILE_OPS |
-		CAP_AUTO_INVAL_DATA | CAP_READDIRPLUS | CAP_NO_OPEN_SUPPORT)
+		CAP_AUTO_INVAL_DATA | CAP_READDIRPLUS | CAP_NO_OPEN_SUPPORT | CAP_PARALLEL_DIROPS)
 
 	if server.opts.EnableLocks {
 		server.kernelSettings.Flags |= CAP_FLOCK_LOCKS | CAP_POSIX_LOCKS


### PR DESCRIPTION
After Linux VFS was enhanced to be able to do several lookups and
readdirs in parallel, FUSE client in Linux, in fear to break existing
filesystems, explicitly reverted it back to be serial in FUSE exchange
and requested filesystems to indicate via CAP_PARALLEL_DIROPS flag that
the filesystem server is ready to handle parallel lookup and readdir
requests.

	https://git.kernel.org/linus/5c672ab3f0

We should be ready to handle and we provide MountOptions.SingleThreaded
for those filesystems, which are not ready to handle requests in
parallel.