### PR TITLE
fuse: Add FOPEN_CACHE_DIR

### DIFF
--- a/fuse/types.go
+++ b/fuse/types.go
@@ -253,6 +253,7 @@ const (
 	FOPEN_DIRECT_IO   = (1 << 0)
 	FOPEN_KEEP_CACHE  = (1 << 1)
 	FOPEN_NONSEEKABLE = (1 << 2)
+	FOPEN_CACHE_DIR   = (1 << 3)
 )
 
 type OpenOut struct {


### PR DESCRIPTION
FOPEN_CACHE_DIR was added in Linux 4.19:

https://git.kernel.org/linus/6433b8998a