### PR TITLE
fixup! rename NodeAttr to StableAttr

### DIFF
--- a/nodefs/inode.go
+++ b/nodefs/inode.go
@@ -127,7 +127,7 @@ func (n *Inode) setEntryOut(out *fuse.EntryOut) {
 }
 
 // StableAttr returns the (Ino, Gen) tuple for this node.
-func (n *Inode) StableAttr() NodeAttr {
+func (n *Inode) StableAttr() StableAttr {
 	return n.nodeAttr
 }
 


### PR DESCRIPTION
I saw build error when running tests:

	(neo) (z-dev) (g.env) kirr@deco:~/src/neo/src/github.com/hanwen/go-fuse$ go test ./...
	# github.com/hanwen/go-fuse/nodefs
	nodefs/inode.go:130:30: undefined: NodeAttr
	FAIL    github.com/hanwen/go-fuse/benchmark [build failed]
	...