### PR TITLE
fuse: Add FOPEN_STREAM

### DIFF
--- a/fuse/print.go
+++ b/fuse/print.go
@@ -69,6 +69,7 @@ var (
 		FOPEN_KEEP_CACHE:  "CACHE",
 		FOPEN_NONSEEKABLE: "NONSEEK",
 		FOPEN_CACHE_DIR:   "CACHE_DIR",
+		FOPEN_STREAM:      "STREAM",
 	}
 	accessFlagName = map[int64]string{
 		X_OK: "x",

--- a/fuse/types.go
+++ b/fuse/types.go
@@ -254,6 +254,7 @@ const (
 	FOPEN_KEEP_CACHE  = (1 << 1)
 	FOPEN_NONSEEKABLE = (1 << 2)
 	FOPEN_CACHE_DIR   = (1 << 3)
+	FOPEN_STREAM      = (1 << 4)
 )
 
 type OpenOut struct {


### PR DESCRIPTION
FOPEN_STREAM, together with FOPEN_NONSEEKABLE must be used on
stream-like file handles that provide both read and write to avoid
hitting deadlock in the kernel.

Please see the following kernel patch for details on how the deadlock
can happen:

https://git.kernel.org/linus/10dce8af3422

Adding FOPEN_STREAM to kernel FUSE is still in the works, but is likely
to enter mainline kernel one way or another:

https://lore.kernel.org/linux-fsdevel/dc47c061f20c464ccf46b43822b062dca6486e90.1553637462.git.kirr@nexedi.com/
https://lore.kernel.org/linux-fsdevel/CAHk-=whQQdoQsgEx1vO7OkfPDcV5hurPnMRLgzfXAPN63n5Sbg@mail.gmail.com/

Here is example for FOPEN_STREAM usage:

https://lab.nexedi.com/kirr/wendelin.core/blob/7783ecf4/wcfs/misc.go#L327-335
https://lab.nexedi.com/kirr/wendelin.core/blob/7783ecf4/wcfs/misc.go#L276-428