### PR TITLE
dirstream_linux: fix zero terminator search

### DIFF
--- a/nodefs/dirstream_linux.go
+++ b/nodefs/dirstream_linux.go
@@ -63,12 +63,14 @@ func (ds *loopbackDirStream) Next() (fuse.DirEntry, syscall.Errno) {
 	nameBytes := ds.todo[unsafe.Offsetof(syscall.Dirent{}.Name):de.Reclen]
 	ds.todo = ds.todo[de.Reclen:]
 
-	for l := len(nameBytes); l > 0; l-- {
-		if nameBytes[l-1] != 0 {
+	// After the loop, l contains the index of the first '\0'.
+	l := 0
+	for l = range nameBytes {
+		if nameBytes[l] == 0 {
 			break
 		}
-		nameBytes = nameBytes[:l-1]
 	}
+	nameBytes = nameBytes[:l]
 	result := fuse.DirEntry{
 		Ino:  de.Ino,
 		Mode: (uint32(de.Type) << 12),


### PR DESCRIPTION
The old code searched for the first non-null byte from the end of
the slice. This assumes that all bytes after the name are initialized
to zero, which does not hold true on Linux 4.15.

Instead, search for the first null byte from the start of the slice,
which is guaranteed by man(3) readdir.

Fixes https://github.com/hanwen/go-fuse/issues/287