### PR TITLE
fuse: Don't skip WRITE details in debug output

### DIFF
--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -733,6 +733,7 @@ func init() {
 		_OP_MKNOD:           func(ptr unsafe.Pointer) interface{} { return (*MknodIn)(ptr) },
 		_OP_CREATE:          func(ptr unsafe.Pointer) interface{} { return (*CreateIn)(ptr) },
 		_OP_READ:            func(ptr unsafe.Pointer) interface{} { return (*ReadIn)(ptr) },
+		_OP_WRITE:           func(ptr unsafe.Pointer) interface{} { return (*WriteIn)(ptr) },
 		_OP_READDIR:         func(ptr unsafe.Pointer) interface{} { return (*ReadIn)(ptr) },
 		_OP_ACCESS:          func(ptr unsafe.Pointer) interface{} { return (*AccessIn)(ptr) },
 		_OP_FORGET:          func(ptr unsafe.Pointer) interface{} { return (*ForgetIn)(ptr) },


### PR DESCRIPTION
When kernel sends WRITE request it sends with it file handle, offset,
size etc. We were not printing all this. Compare e.g. debug output
sample for TestUtimesNano before and after the patch.

before:

	rx 8: CREATE i1 {0100600 [CREAT,TRUNC,WRONLY,0x8000] (00)} ["hello.txt"] 10b
	tx 8:     OK, {i3 g2 {M0100600 SZ=0 L=1 1000:1000 B0*4096 i0:733462 A 1556038355.426630 M 1556038355.426630 C 1556038355.426630} &{2 0 0}}
	rx 9: GETXATTR i3 {sz 0} ["security.capability"] 20b
	tx 9:     61=no data available
	rx 10: WRITE i3  3b							<-- NOTE
	tx 10:     OK

after:

	rx 8: CREATE i1 {0100600 [WRONLY,CREAT,TRUNC,0x8000] (00)} ["hello.txt"] 10b
	tx 8:     OK, {i3 g2 {M0100600 SZ=0 L=1 1000:1000 B0*4096 i0:736300 A 1556038379.359197 M 1556038379.359197 C 1556038379.359197} &{2 0 0}}
	rx 9: GETXATTR i3 {sz 0} ["security.capability"] 20b
	tx 9:     61=no data available
	rx 10: WRITE i3 {Fh 2 [0 +3)  L 0 WRONLY,NONBLOCK,0x8000}  3b		<-- NOTE
	tx 10:     OK