### PR TITLE
Support custom logger for fuse.Server

### DIFF
--- a/fuse/log.go
+++ b/fuse/log.go
@@ -1,0 +1,8 @@
+package fuse
+
+// Logger allows the use of custom loggers in the FUSE server. The log.Logger
+// in the standard library implements this interface.
+type Logger interface {
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
+}


### PR DESCRIPTION
The library currently uses the default logger to print messages like this to stderr without the ability to turn it off.

```
2019/05/25 13:16:26 Unimplemented opcode POLL
```

This PR adds a custom logger to fuse.Server which, in addition to making loggig more flexible, makes it possible to disable output like so:

```go
server.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
```

It does not however address the issue in other parts of the library which also appear to use the default logger. Let me know if you'd prefer a different implementation, or one that covers other packages too.