### PR TITLE
Avoid nil ptr panic in GetAttr()

### DIFF
--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -603,17 +603,15 @@ func (n *pathInode) GetAttr(out *fuse.Attr, file nodefs.File, context *fuse.Cont
 	}
 	// If we don't have an open file, or fstat on it failed due to an internal
 	// error, stat by path.
-	if file == nil || code == fuse.ENOSYS || code == fuse.EBADF {
-		fi, code = n.fs.GetAttr(n.GetPath(), context)
-		if !code.Ok() {
-			return code
-		}
-		// This is a bug in the filesystem implementation, but let's not
-		// crash.
-		if fi == nil {
-			log.Printf("Bug: fs.GetAttr returned OK with nil data")
-			return fuse.EINVAL
-		}
+	fi, code = n.fs.GetAttr(n.GetPath(), context)
+	if !code.Ok() {
+		return code
+	}
+	// This is a bug in the filesystem implementation, but let's not
+	// crash.
+	if fi == nil {
+		log.Printf("Bug: fs.GetAttr returned OK with nil data")
+		return fuse.EINVAL
 	}
 	// Set inode number (unless already set or disabled).
 	n.setClientInode(fi.Ino)


### PR DESCRIPTION
This PR removes the chance of the nil ptr panic in https://github.com/hanwen/go-fuse/issues/298. Before this change, the only way to avoid a panic is for the `if file == nil || code == fuse.ENOSYS || code == fuse.EBADF` condition to be true, since only then would `fi` be set to something non-nil. So it's not really a condition anymore, and https://github.com/hanwen/go-fuse/commit/47211c2bf0c4ff9da52f38c039ca6538dc6f363d has made it obsolete anyway.