### PR TITLE
Renameat2 has been removed and used to implement Renameat instead

### DIFF
--- a/fs/loopback_linux.go
+++ b/fs/loopback_linux.go
@@ -64,7 +64,7 @@ func (n *loopbackNode) renameExchange(name string, newparent *loopbackNode, newN
 		return syscall.EBUSY
 	}
 
-	return ToErrno(unix.Renameat2(fd1, name, fd2, newName, unix.RENAME_EXCHANGE))
+	return ToErrno(unix.Renameat(fd1, name, fd2, newName))
 }
 
 func (n *loopbackNode) CopyFileRange(ctx context.Context, fhIn FileHandle,


### PR DESCRIPTION
Upstream change to `golang.org/x/sys/unix` moves the implementation of `Renameat2` to `Renameat` and removes the necessity of `RENAME_EXCHANGE` flag.