### PR TITLE
Revert breaking changes

### DIFF
--- a/benchmark/stat_test.go
+++ b/benchmark/stat_test.go
@@ -17,9 +17,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func setupFs(node fs.InodeEmbedder, N int) (string, func()) {

--- a/benchmark/statfs.go
+++ b/benchmark/statfs.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type StatFS struct {

--- a/example/autounionfs/main.go
+++ b/example/autounionfs/main.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/unionfs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/unionfs"
 )
 
 func main() {

--- a/example/hello/main.go
+++ b/example/hello/main.go
@@ -12,8 +12,8 @@ import (
 	"log"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type HelloRoot struct {

--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/fs"
 )
 
 func writeMemProfile(fn string, sigs <-chan os.Signal) {

--- a/example/memfs/main.go
+++ b/example/memfs/main.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 func main() {

--- a/example/multizip/main.go
+++ b/example/multizip/main.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/zipfs"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/zipfs"
 )
 
 func main() {

--- a/example/statfs/main.go
+++ b/example/statfs/main.go
@@ -20,9 +20,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/benchmark"
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/benchmark"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func main() {

--- a/example/unionfs/main.go
+++ b/example/unionfs/main.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/unionfs"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/unionfs"
 )
 
 func main() {

--- a/example/zipfs/main.go
+++ b/example/zipfs/main.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/zipfs"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/zipfs"
 )
 
 func main() {

--- a/fs/api.go
+++ b/fs/api.go
@@ -171,7 +171,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // InodeEmbedder is an interface for structs that embed Inode.

--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal"
 )
 
 func errnoToStatus(errno syscall.Errno) fuse.Status {

--- a/fs/cache_test.go
+++ b/fs/cache_test.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type keepCacheFile struct {

--- a/fs/constants.go
+++ b/fs/constants.go
@@ -7,7 +7,7 @@ package fs
 import (
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // OK is the Errno return value to indicate absense of errors.

--- a/fs/directio_example_test.go
+++ b/fs/directio_example_test.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // bytesFileHandle is a file handle that carries separate content for

--- a/fs/directio_test.go
+++ b/fs/directio_test.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type dioRoot struct {

--- a/fs/dirstream.go
+++ b/fs/dirstream.go
@@ -7,7 +7,7 @@ package fs
 import (
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type dirArray struct {

--- a/fs/dirstream_darwin.go
+++ b/fs/dirstream_darwin.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func NewLoopbackDirStream(nm string) (DirStream, syscall.Errno) {

--- a/fs/dirstream_linux.go
+++ b/fs/dirstream_linux.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type loopbackDirStream struct {

--- a/fs/dynamic_example_test.go
+++ b/fs/dynamic_example_test.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // numberNode is a filesystem node representing an integer. Prime

--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -10,8 +10,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // ExampleMount shows how to create a loopback file system, and

--- a/fs/files.go
+++ b/fs/files.go
@@ -12,7 +12,7 @@ import (
 
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 	"golang.org/x/sys/unix"
 )
 

--- a/fs/files_linux.go
+++ b/fs/files_linux.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func (f *loopbackFile) Allocate(ctx context.Context, off uint64, sz uint64, mode uint32) syscall.Errno {

--- a/fs/inmemory_example_test.go
+++ b/fs/inmemory_example_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // files contains the files we will expose as a file system

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type parentData struct {

--- a/fs/interrupt_test.go
+++ b/fs/interrupt_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type interruptRoot struct {

--- a/fs/loopback.go
+++ b/fs/loopback.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type loopbackRoot struct {

--- a/fs/loopback_darwin.go
+++ b/fs/loopback_darwin.go
@@ -12,8 +12,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/utimens"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/utimens"
 )
 
 func (n *loopbackNode) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, syscall.Errno) {

--- a/fs/loopback_linux_test.go
+++ b/fs/loopback_linux_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 	"github.com/kylelemons/godebug/pretty"
 	"golang.org/x/sys/unix"
 )

--- a/fs/mem.go
+++ b/fs/mem.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // MemRegularFile is a filesystem node that holds a read-only data

--- a/fs/mem_test.go
+++ b/fs/mem_test.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func testMount(t *testing.T, root InodeEmbedder, opts *Options) (string, *fuse.Server, func()) {

--- a/fs/mount.go
+++ b/fs/mount.go
@@ -7,7 +7,7 @@ package fs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // Mount mounts the given NodeFS on the directory, and starts serving

--- a/fs/readonly_test.go
+++ b/fs/readonly_test.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func TestReadonlyCreate(t *testing.T) {

--- a/fs/readwrite_handleless_example_test.go
+++ b/fs/readwrite_handleless_example_test.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // bytesNode is a file that can be read and written

--- a/fs/simple_test.go
+++ b/fs/simple_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
-	"github.com/hanwen/go-fuse/v2/posixtest"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
+	"github.com/hanwen/go-fuse/posixtest"
 )
 
 type testCase struct {

--- a/fs/zip_test.go
+++ b/fs/zip_test.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/fs"
 )
 
 var testData = map[string]string{

--- a/fs/zipfs_example_test.go
+++ b/fs/zipfs_example_test.go
@@ -17,8 +17,8 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // zipFile is a file read from a zip archive.

--- a/fuse/nodefs/api.go
+++ b/fuse/nodefs/api.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // This package is deprecated. New projects should use the package
-// "github.com/hanwen/go-fuse/v2/fs" instead.
+// "github.com/hanwen/go-fuse/fs" instead.
 //
 // The nodefs package offers a high level API that resembles the
 // kernel's idea of what an FS looks like.  File systems can have
@@ -15,7 +15,7 @@ package nodefs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // The Node interface implements the user-defined file system

--- a/fuse/nodefs/defaultfile.go
+++ b/fuse/nodefs/defaultfile.go
@@ -7,7 +7,7 @@ package nodefs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type defaultFile struct{}

--- a/fuse/nodefs/defaultnode.go
+++ b/fuse/nodefs/defaultnode.go
@@ -7,7 +7,7 @@ package nodefs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // NewDefaultNode returns an implementation of Node that returns

--- a/fuse/nodefs/dir.go
+++ b/fuse/nodefs/dir.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type connectorDir struct {

--- a/fuse/nodefs/fileless_test.go
+++ b/fuse/nodefs/fileless_test.go
@@ -8,8 +8,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type nodeReadNode struct {

--- a/fuse/nodefs/files.go
+++ b/fuse/nodefs/files.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // DataFile is for implementing read-only filesystems.  This

--- a/fuse/nodefs/files_darwin.go
+++ b/fuse/nodefs/files_darwin.go
@@ -9,8 +9,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/utimens"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/utimens"
 )
 
 func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {

--- a/fuse/nodefs/files_linux.go
+++ b/fuse/nodefs/files_linux.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {

--- a/fuse/nodefs/files_test.go
+++ b/fuse/nodefs/files_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 // Check that loopbackFile.Utimens() works as expected

--- a/fuse/nodefs/fsconnector.go
+++ b/fuse/nodefs/fsconnector.go
@@ -16,7 +16,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // Tests should set to true.

--- a/fuse/nodefs/fsmount.go
+++ b/fuse/nodefs/fsmount.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // openedFile stores either an open dir or an open file.

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // Returns the RawFileSystem so it can be mounted.

--- a/fuse/nodefs/fuse.go
+++ b/fuse/nodefs/fuse.go
@@ -5,7 +5,7 @@
 package nodefs
 
 import (
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // Mount mounts a filesystem with the given root node on the given directory.

--- a/fuse/nodefs/inode.go
+++ b/fuse/nodefs/inode.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type parentData struct {

--- a/fuse/nodefs/lockingfile.go
+++ b/fuse/nodefs/lockingfile.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type lockingFile struct {

--- a/fuse/nodefs/memnode.go
+++ b/fuse/nodefs/memnode.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // NewMemNodeFSRoot creates an in-memory node-based filesystem. Files

--- a/fuse/nodefs/memnode_test.go
+++ b/fuse/nodefs/memnode_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 const testTtl = 100 * time.Millisecond

--- a/fuse/pathfs/api.go
+++ b/fuse/pathfs/api.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // This package is deprecated. New projects should use the package
-// "github.com/hanwen/go-fuse/v2/fs" instead.
+// "github.com/hanwen/go-fuse/fs" instead.
 //
 // Package pathfs provides a file system API expressed in filenames.
 package pathfs
@@ -11,8 +11,8 @@ package pathfs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 // A filesystem API that uses paths rather than inodes.  A minimal

--- a/fuse/pathfs/copy.go
+++ b/fuse/pathfs/copy.go
@@ -7,7 +7,7 @@ package pathfs
 import (
 	"os"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func CopyFile(srcFs, destFs FileSystem, srcFile, destFile string, context *fuse.Context) fuse.Status {

--- a/fuse/pathfs/copy_test.go
+++ b/fuse/pathfs/copy_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func TestCopyFile(t *testing.T) {

--- a/fuse/pathfs/default.go
+++ b/fuse/pathfs/default.go
@@ -7,8 +7,8 @@ package pathfs
 import (
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 // NewDefaultFileSystem creates a filesystem that responds ENOSYS for

--- a/fuse/pathfs/locking.go
+++ b/fuse/pathfs/locking.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 type lockingFileSystem struct {

--- a/fuse/pathfs/loopback.go
+++ b/fuse/pathfs/loopback.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal"
 )
 
 type loopbackFileSystem struct {

--- a/fuse/pathfs/loopback_darwin.go
+++ b/fuse/pathfs/loopback_darwin.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/utimens"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/utimens"
 )
 
 func (fs *loopbackFileSystem) Utimens(path string, a *time.Time, m *time.Time, context *fuse.Context) fuse.Status {

--- a/fuse/pathfs/loopback_linux.go
+++ b/fuse/pathfs/loopback_linux.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func (fs *loopbackFileSystem) ListXAttr(name string, context *fuse.Context) ([]string, fuse.Status) {

--- a/fuse/pathfs/loopback_test.go
+++ b/fuse/pathfs/loopback_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 // Check that loopbackFileSystem.Utimens() works as expected

--- a/fuse/pathfs/owner_test.go
+++ b/fuse/pathfs/owner_test.go
@@ -9,9 +9,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type ownerFs struct {

--- a/fuse/pathfs/pathfs.go
+++ b/fuse/pathfs/pathfs.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 // refCountedInode is used in clientInodeMap. The reference count is used to decide

--- a/fuse/pathfs/prefixfs.go
+++ b/fuse/pathfs/prefixfs.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 // PrefixFileSystem adds a path prefix to incoming calls.

--- a/fuse/pathfs/readonlyfs.go
+++ b/fuse/pathfs/readonlyfs.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
 )
 
 // NewReadonlyFileSystem returns a wrapper that only exposes read-only

--- a/fuse/pathfs/xattr_test.go
+++ b/fuse/pathfs/xattr_test.go
@@ -13,9 +13,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 var xattrGolden = map[string][]byte{

--- a/fuse/splice_linux.go
+++ b/fuse/splice_linux.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hanwen/go-fuse/v2/splice"
+	"github.com/hanwen/go-fuse/splice"
 )
 
 func (s *Server) setSplice() {

--- a/fuse/test/cache_test.go
+++ b/fuse/test/cache_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type cacheFs struct {
@@ -54,7 +54,7 @@ func setupCacheTest(t *testing.T) (string, *pathfs.PathNodeFs, func()) {
 	}
 
 	opts := nodefs.NewOptions()
-	opts.AttrTimeout = 10 * time.Millisecond
+	opts.AttrTimeout = 10*time.Millisecond
 	opts.Debug = testutil.VerboseTest()
 	state, _, err := nodefs.Mount(dir+"/mnt", pfs.Root(), mntOpts, opts)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestFopenKeepCache(t *testing.T) {
 	}
 
 	// sleep a bit to make sure mtime of file for before and after are different
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(20*time.Millisecond)
 
 	xwriteFile(wd+"/orig/file.txt", after)
 	mtimeAfter := xstat(wd + "/orig/file.txt").ModTime()
@@ -134,7 +134,7 @@ func TestFopenKeepCache(t *testing.T) {
 	//
 	// this way we make sure the kernel knows updated size/mtime before we
 	// try to read the file next time.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100*time.Millisecond)
 	_ = xstat(wd + "/mnt/file.txt")
 
 	c = xreadFile(wd + "/mnt/file.txt")

--- a/fuse/test/cachecontrol_test.go
+++ b/fuse/test/cachecontrol_test.go
@@ -15,9 +15,9 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 // DataNode is a nodefs.Node that Reads static data.

--- a/fuse/test/defaultnode_test.go
+++ b/fuse/test/defaultnode_test.go
@@ -10,9 +10,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func TestDefaultNodeGetAttr(t *testing.T) {

--- a/fuse/test/defaultread_test.go
+++ b/fuse/test/defaultread_test.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type DefaultReadFS struct {

--- a/fuse/test/delete_linux_test.go
+++ b/fuse/test/delete_linux_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type flipNode struct {

--- a/fuse/test/file_lock_test.go
+++ b/fuse/test/file_lock_test.go
@@ -15,9 +15,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func TestFlockExclusive(t *testing.T) {

--- a/fuse/test/fsetattr_test.go
+++ b/fuse/test/fsetattr_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type MutableDataFile struct {

--- a/fuse/test/loopback_linux_test.go
+++ b/fuse/test/loopback_linux_test.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func TestTouch(t *testing.T) {

--- a/fuse/test/loopback_test.go
+++ b/fuse/test/loopback_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type testCase struct {

--- a/fuse/test/mount_test.go
+++ b/fuse/test/mount_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func TestMountOnExisting(t *testing.T) {

--- a/fuse/test/nil_file_truncation_test.go
+++ b/fuse/test/nil_file_truncation_test.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type truncatableFile struct {

--- a/fuse/test/node_test.go
+++ b/fuse/test/node_test.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type rootNode struct {

--- a/fuse/test/nofile_test.go
+++ b/fuse/test/nofile_test.go
@@ -10,9 +10,9 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 // exercise functionality when open returns 0 file handle.

--- a/fuse/test/notify_linux_test.go
+++ b/fuse/test/notify_linux_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type NotifyFs struct {

--- a/fuse/test/umask_test.go
+++ b/fuse/test/umask_test.go
@@ -10,10 +10,10 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type umaskFS struct {

--- a/fuse/test/xattr_test.go
+++ b/fuse/test/xattr_test.go
@@ -12,9 +12,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 // this file is linux-only, since it uses syscall.Getxattr.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hanwen/go-fuse/v2
+module github.com/hanwen/go-fuse
 
 require (
 	github.com/hanwen/go-fuse v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/hanwen/go-fuse
 
 require (
-	github.com/hanwen/go-fuse v1.0.0
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	golang.org/x/sys v0.0.0-20180830151530-49385e6e1522
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/hanwen/go-fuse v1.0.0 h1:GxS9Zrn6c35/BnfiVsZVWmsG803xwE7eVRDvcf/BEVc=
-github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // Check that loopback Utimens() works as expected.

--- a/internal/utimens/utimens_darwin.go
+++ b/internal/utimens/utimens_darwin.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // timeToTimeval converts time.Time to syscall.Timeval

--- a/newunionfs/unionfs.go
+++ b/newunionfs/unionfs.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 func filePathHash(path string) string {

--- a/newunionfs/unionfs_test.go
+++ b/newunionfs/unionfs_test.go
@@ -13,10 +13,10 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
-	"github.com/hanwen/go-fuse/v2/posixtest"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
+	"github.com/hanwen/go-fuse/posixtest"
 )
 
 type testCase struct {

--- a/posixtest/test.go
+++ b/posixtest/test.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 var All = map[string]func(*testing.T, string){

--- a/unionfs/autounion.go
+++ b/unionfs/autounion.go
@@ -15,9 +15,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
 type knownFs struct {

--- a/unionfs/autounion_test.go
+++ b/unionfs/autounion_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 const entryTTL = 100 * time.Millisecond

--- a/unionfs/cachingfs.go
+++ b/unionfs/cachingfs.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
 const _XATTRSEP = "@XATTR@"

--- a/unionfs/cachingfs_test.go
+++ b/unionfs/cachingfs_test.go
@@ -9,9 +9,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func modeMapEq(m1, m2 map[string]uint32) bool {

--- a/unionfs/create.go
+++ b/unionfs/create.go
@@ -7,7 +7,7 @@ package unionfs
 import (
 	"os"
 
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
 func NewUnionFsFromRoots(roots []string, opts *UnionFsOptions, roCaching bool) (pathfs.FileSystem, error) {

--- a/unionfs/dircache.go
+++ b/unionfs/dircache.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
 // newDirnameMap reads the contents of the given directory. On error,

--- a/unionfs/unionfs.go
+++ b/unionfs/unionfs.go
@@ -16,9 +16,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
 func filePathHash(path string) string {

--- a/unionfs/unionfs_test.go
+++ b/unionfs/unionfs_test.go
@@ -18,11 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
-	"github.com/hanwen/go-fuse/v2/posixtest"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
+	"github.com/hanwen/go-fuse/posixtest"
 )
 
 func TestFilePathHash(t *testing.T) {

--- a/unionfs/unionfs_xattr_test.go
+++ b/unionfs/unionfs_xattr_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
-	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 type TestFS struct {

--- a/zipfs/multizip.go
+++ b/zipfs/multizip.go
@@ -19,8 +19,8 @@ import (
 	"log"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // MultiZipFs is a filesystem that mounts zipfiles.

--- a/zipfs/multizip_test.go
+++ b/zipfs/multizip_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 const testTtl = 100 * time.Millisecond

--- a/zipfs/tarfs.go
+++ b/zipfs/tarfs.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 // TODO - handle symlinks.

--- a/zipfs/tarfs_test.go
+++ b/zipfs/tarfs_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 var tarContents = map[string]string{

--- a/zipfs/zipfs.go
+++ b/zipfs/zipfs.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
 )
 
 type zipRoot struct {

--- a/zipfs/zipfs_test.go
+++ b/zipfs/zipfs_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanwen/go-fuse/v2/fs"
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/hanwen/go-fuse/v2/internal/testutil"
+	"github.com/hanwen/go-fuse/fs"
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/internal/testutil"
 )
 
 func testZipFile() string {


### PR DESCRIPTION
Linked to #312 
Revert change of module path to /v2, doesn't align with project structure, breaks non-module projects, and breaks pre-change existing projects.