### PR TITLE
attempt to mount directly using syscall if running as root

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -116,6 +116,13 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 }
 
 func unmount(mountPoint string) (err error) {
+	if os.Geteuid() == 0 {
+		err := syscall.Unmount(mountPoint, 0)
+		if err == nil {
+			return nil
+		}
+	}
+
 	bin, err := fusermountBinary()
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolves https://github.com/hanwen/go-fuse/issues/314

When attempting to mount fuse, if running as root we first attempt to open /dev/fuse and use syscall.Mount. If either part of the process fails this falls back on the standard process and should typically have no adverse effects.

This is however missing handling of some specific mount options usually handled by fusermount such as blkdev, auto_unmount. In this kind of case syscall.Mount will return EINVAL and the process will fallback to fusermount.

Suggested improvements:
* Add an option to MountOptions to enable this instead of using current effective user id
* Allow customization of mount flags (also MountOptions)