### PR TITLE
zipfs: fix "got block count 8, want 1" test failure

### DIFF
--- a/zipfs/zipfs.go
+++ b/zipfs/zipfs.go
@@ -84,7 +84,9 @@ func (zf *zipFile) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrO
 	out.Atime = out.Mtime
 	out.Ctime = out.Mtime
 	out.Size = zf.file.UncompressedSize64
-	out.Blocks = (out.Size + 511) / 512
+	const bs = 512
+	out.Blksize = bs
+	out.Blocks = (out.Size + bs - 1) / bs
 	return 0
 }
 


### PR DESCRIPTION
Failure was:

    zipfs_test.go:74: got block count 8, want 1

This got broken by "fs: set Blksize and Blocks automatically based on Size",
fix it by setting Blksize.