### PR TITLE
Loopback name

### DIFF
--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -89,6 +89,8 @@ func main() {
 	}
 	opts.Debug = *debug
 	opts.AllowOther = *other
+	// Second column in "df -T" will be shown as "fuse." + Name
+	opts.MountOptions.Name = "loopback"
 	server, err := fs.Mount(flag.Arg(0), loopbackRoot, opts)
 	if err != nil {
 		log.Fatalf("Mount fail: %v\n", err)

--- a/zipfs/zipfs.go
+++ b/zipfs/zipfs.go
@@ -84,7 +84,9 @@ func (zf *zipFile) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrO
 	out.Atime = out.Mtime
 	out.Ctime = out.Mtime
 	out.Size = zf.file.UncompressedSize64
-	out.Blocks = (out.Size + 511) / 512
+	const bs = 512
+	out.Blksize = bs
+	out.Blocks = (out.Size + bs - 1) / bs
 	return 0
 }
 


### PR DESCRIPTION
I really tried to send this via gerrithub as per the CONTRIBUTING instructions. But it looks like gerrithub is having a bad day or I'm doing something stupid. I generated the `Change-Id` both via the urandom magic from CONTRIBUTING and via the hook provided by gerrithub, but the result stayed the same:

```
~/go/src/github.com/hanwen/go-fuse$ git push ssh://rfjakob@review.gerrithub.io:29418/hanwen/go-fuse HEAD:refs/for/master
Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 4 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (9/9), 1.31 KiB | 1.31 MiB/s, done.
Total 9 (delta 6), reused 0 (delta 0)
remote: Resolving deltas: 100% (6/6)
remote: Processing changes: refs: 1, done    
remote: ERROR: commit 8458b8a: missing Change-Id in message footer
remote: 
remote: Hint: to automatically insert a Change-Id, install the hook:
remote:   gitdir=$(git rev-parse --git-dir); scp -p -P 29418 rfjakob@review.gerrithub.io:hooks/commit-msg ${gitdir}/hooks/
remote: and then amend the commit:
remote:   git commit --amend --no-edit
remote: Finally, push your changes again
remote: 
To ssh://review.gerrithub.io:29418/hanwen/go-fuse
 ! [remote rejected] HEAD -> refs/for/master (commit 8458b8a: missing Change-Id in message footer)
error: failed to push some refs to 'ssh://rfjakob@review.gerrithub.io:29418/hanwen/go-fuse'
```