### PR TITLE
FYI: nodefs: Propagate context to File methods

### DIFF
--- a/fuse/nodefs/api.go
+++ b/fuse/nodefs/api.go
@@ -144,34 +144,34 @@ type File interface {
 	// the inner file here.
 	InnerFile() File
 
-	Read(dest []byte, off int64) (fuse.ReadResult, fuse.Status)
-	Write(data []byte, off int64) (written uint32, code fuse.Status)
+	Read(dest []byte, off int64, ctx *fuse.Context) (fuse.ReadResult, fuse.Status)
+	Write(data []byte, off int64, ctx *fuse.Context) (written uint32, code fuse.Status)
 
 	// File locking
-	GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock) (code fuse.Status)
-	SetLk(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status)
-	SetLkw(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status)
+	GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock, ctx *fuse.Context) (code fuse.Status)
+	SetLk(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status)
+	SetLkw(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status)
 
 	// Flush is called for close() call on a file descriptor. In
 	// case of duplicated descriptor, it may be called more than
 	// once for a file.
-	Flush() fuse.Status
+	Flush(ctx *fuse.Context) fuse.Status
 
 	// This is called to before the file handle is forgotten. This
 	// method has no return value, so nothing can synchronizes on
 	// the call. Any cleanup that requires specific synchronization or
 	// could fail with I/O errors should happen in Flush instead.
-	Release()
-	Fsync(flags int) (code fuse.Status)
+	Release() // XXX +ctx ?
+	Fsync(flags int, ctx *fuse.Context) (code fuse.Status)
 
 	// The methods below may be called on closed files, due to
 	// concurrency.  In that case, you should return EBADF.
-	Truncate(size uint64) fuse.Status
-	GetAttr(out *fuse.Attr) fuse.Status
-	Chown(uid uint32, gid uint32) fuse.Status
-	Chmod(perms uint32) fuse.Status
-	Utimens(atime *time.Time, mtime *time.Time) fuse.Status
-	Allocate(off uint64, size uint64, mode uint32) (code fuse.Status)
+	Truncate(size uint64, ctx *fuse.Context) fuse.Status
+	GetAttr(out *fuse.Attr, ctx *fuse.Context) fuse.Status
+	Chown(uid uint32, gid uint32, ctx *fuse.Context) fuse.Status
+	Chmod(perms uint32, ctx *fuse.Context) fuse.Status
+	Utimens(atime *time.Time, mtime *time.Time, ctx *fuse.Context) fuse.Status
+	Allocate(off uint64, size uint64, mode uint32, ctx *fuse.Context) (code fuse.Status)
 }
 
 // Wrap a File return in this to set FUSE flags.  Also used internally

--- a/fuse/nodefs/defaultfile.go
+++ b/fuse/nodefs/defaultfile.go
@@ -29,27 +29,27 @@ func (f *defaultFile) String() string {
 	return "defaultFile"
 }
 
-func (f *defaultFile) Read(buf []byte, off int64) (fuse.ReadResult, fuse.Status) {
+func (f *defaultFile) Read(buf []byte, off int64, ctx *fuse.Context) (fuse.ReadResult, fuse.Status) {
 	return nil, fuse.ENOSYS
 }
 
-func (f *defaultFile) Write(data []byte, off int64) (uint32, fuse.Status) {
+func (f *defaultFile) Write(data []byte, off int64, ctx *fuse.Context) (uint32, fuse.Status) {
 	return 0, fuse.ENOSYS
 }
 
-func (f *defaultFile) GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock) (code fuse.Status) {
+func (f *defaultFile) GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock, ctx *fuse.Context) (code fuse.Status) {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) SetLk(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status) {
+func (f *defaultFile) SetLk(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status) {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) SetLkw(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status) {
+func (f *defaultFile) SetLkw(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status) {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Flush() fuse.Status {
+func (f *defaultFile) Flush(ctx *fuse.Context) fuse.Status {
 	return fuse.OK
 }
 
@@ -57,30 +57,30 @@ func (f *defaultFile) Release() {
 
 }
 
-func (f *defaultFile) GetAttr(*fuse.Attr) fuse.Status {
+func (f *defaultFile) GetAttr(_ *fuse.Attr, ctx *fuse.Context) fuse.Status {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Fsync(flags int) (code fuse.Status) {
+func (f *defaultFile) Fsync(flags int, ctx *fuse.Context) (code fuse.Status) {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Utimens(atime *time.Time, mtime *time.Time) fuse.Status {
+func (f *defaultFile) Utimens(atime *time.Time, mtime *time.Time, ctx *fuse.Context) fuse.Status {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Truncate(size uint64) fuse.Status {
+func (f *defaultFile) Truncate(size uint64, ctx *fuse.Context) fuse.Status {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Chown(uid uint32, gid uint32) fuse.Status {
+func (f *defaultFile) Chown(uid uint32, gid uint32, ctx *fuse.Context) fuse.Status {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Chmod(perms uint32) fuse.Status {
+func (f *defaultFile) Chmod(perms uint32, ctx *fuse.Context) fuse.Status {
 	return fuse.ENOSYS
 }
 
-func (f *defaultFile) Allocate(off uint64, size uint64, mode uint32) (code fuse.Status) {
+func (f *defaultFile) Allocate(off uint64, size uint64, mode uint32, ctx *fuse.Context) (code fuse.Status) {
 	return fuse.ENOSYS
 }

--- a/fuse/nodefs/defaultnode.go
+++ b/fuse/nodefs/defaultnode.go
@@ -127,7 +127,7 @@ func (n *defaultNode) ListXAttr(context *fuse.Context) (attrs []string, code fus
 
 func (n *defaultNode) GetAttr(out *fuse.Attr, file File, context *fuse.Context) (code fuse.Status) {
 	if file != nil {
-		return file.GetAttr(out)
+		return file.GetAttr(out, context)
 	}
 	if n.Inode().IsDir() {
 		out.Mode = fuse.S_IFDIR | 0755
@@ -171,14 +171,14 @@ func (n *defaultNode) Fallocate(file File, off uint64, size uint64, mode uint32,
 
 func (n *defaultNode) Read(file File, dest []byte, off int64, context *fuse.Context) (fuse.ReadResult, fuse.Status) {
 	if file != nil {
-		return file.Read(dest, off)
+		return file.Read(dest, off, context)
 	}
 	return nil, fuse.ENOSYS
 }
 
 func (n *defaultNode) Write(file File, data []byte, off int64, context *fuse.Context) (written uint32, code fuse.Status) {
 	if file != nil {
-		return file.Write(data, off)
+		return file.Write(data, off, context)
 	}
 	return 0, fuse.ENOSYS
 }

--- a/fuse/nodefs/files_linux.go
+++ b/fuse/nodefs/files_linux.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 )
 
-func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {
+func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32, ctx *fuse.Context) fuse.Status {
 	f.lock.Lock()
-	err := syscall.Fallocate(int(f.File.Fd()), mode, int64(off), int64(sz))
+	err := syscall.Fallocate(int(f.File.Fd()), mode, int64(off), int64(sz))	// XXX cancel not propagated
 	f.lock.Unlock()
 	if err != nil {
 		return fuse.ToStatus(err)
@@ -22,12 +22,12 @@ func (f *loopbackFile) Allocate(off uint64, sz uint64, mode uint32) fuse.Status 
 }
 
 // Utimens - file handle based version of loopbackFileSystem.Utimens()
-func (f *loopbackFile) Utimens(a *time.Time, m *time.Time) fuse.Status {
+func (f *loopbackFile) Utimens(a *time.Time, m *time.Time, ctx *fuse.Context) fuse.Status {
 	var ts [2]syscall.Timespec
 	ts[0] = fuse.UtimeToTimespec(a)
 	ts[1] = fuse.UtimeToTimespec(m)
 	f.lock.Lock()
-	err := futimens(int(f.File.Fd()), &ts)
+	err := futimens(int(f.File.Fd()), &ts) // XXX cancel not propagated
 	f.lock.Unlock()
 	return fuse.ToStatus(err)
 }

--- a/fuse/nodefs/files_test.go
+++ b/fuse/nodefs/files_test.go
@@ -26,7 +26,7 @@ func TestLoopbackFileUtimens(t *testing.T) {
 	f := NewLoopbackFile(f2)
 
 	utimensFn := func(atime *time.Time, mtime *time.Time) fuse.Status {
-		return f.Utimens(atime, mtime)
+		return f.Utimens(atime, mtime, &fuse.Context{Cancel: nil})
 	}
 	testutil.TestLoopbackUtimens(t, path, utimensFn)
 }

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -28,7 +28,7 @@ func (c *rawBridge) Fsync(cancel <-chan struct{}, input *fuse.FsyncIn) fuse.Stat
 	opened := node.mount.getOpenedFile(input.Fh)
 
 	if opened != nil {
-		return opened.WithFlags.File.Fsync(int(input.FsyncFlags))
+		return opened.WithFlags.File.Fsync(int(input.FsyncFlags), &fuse.Context{Caller: input.Caller, Cancel: cancel})
 	}
 
 	return fuse.ENOSYS
@@ -491,7 +491,7 @@ func (c *rawBridge) Flush(cancel <-chan struct{}, input *fuse.FlushIn) fuse.Stat
 	opened := node.mount.getOpenedFile(input.Fh)
 
 	if opened != nil {
-		return opened.WithFlags.File.Flush()
+		return opened.WithFlags.File.Flush(&fuse.Context{Caller: input.Caller, Cancel: cancel})
 	}
 	return fuse.OK
 }

--- a/fuse/nodefs/lockingfile.go
+++ b/fuse/nodefs/lockingfile.go
@@ -36,40 +36,40 @@ func (f *lockingFile) String() string {
 	return fmt.Sprintf("lockingFile(%s)", f.file.String())
 }
 
-func (f *lockingFile) Read(buf []byte, off int64) (fuse.ReadResult, fuse.Status) {
+func (f *lockingFile) Read(buf []byte, off int64, ctx *fuse.Context) (fuse.ReadResult, fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Read(buf, off)
+	return f.file.Read(buf, off, ctx)
 }
 
-func (f *lockingFile) Write(data []byte, off int64) (uint32, fuse.Status) {
+func (f *lockingFile) Write(data []byte, off int64, ctx *fuse.Context) (uint32, fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Write(data, off)
+	return f.file.Write(data, off, ctx)
 }
 
-func (f *lockingFile) Flush() fuse.Status {
+func (f *lockingFile) Flush(ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Flush()
+	return f.file.Flush(ctx)
 }
 
-func (f *lockingFile) GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock) (code fuse.Status) {
+func (f *lockingFile) GetLk(owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock, ctx *fuse.Context) (code fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.GetLk(owner, lk, flags, out)
+	return f.file.GetLk(owner, lk, flags, out, ctx)
 }
 
-func (f *lockingFile) SetLk(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status) {
+func (f *lockingFile) SetLk(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.SetLk(owner, lk, flags)
+	return f.file.SetLk(owner, lk, flags, ctx)
 }
 
-func (f *lockingFile) SetLkw(owner uint64, lk *fuse.FileLock, flags uint32) (code fuse.Status) {
+func (f *lockingFile) SetLkw(owner uint64, lk *fuse.FileLock, flags uint32, ctx *fuse.Context) (code fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.SetLkw(owner, lk, flags)
+	return f.file.SetLkw(owner, lk, flags, ctx)
 }
 
 func (f *lockingFile) Release() {
@@ -78,44 +78,44 @@ func (f *lockingFile) Release() {
 	f.file.Release()
 }
 
-func (f *lockingFile) GetAttr(a *fuse.Attr) fuse.Status {
+func (f *lockingFile) GetAttr(a *fuse.Attr, ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.GetAttr(a)
+	return f.file.GetAttr(a, ctx)
 }
 
-func (f *lockingFile) Fsync(flags int) (code fuse.Status) {
+func (f *lockingFile) Fsync(flags int, ctx *fuse.Context) (code fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Fsync(flags)
+	return f.file.Fsync(flags, ctx)
 }
 
-func (f *lockingFile) Utimens(atime *time.Time, mtime *time.Time) fuse.Status {
+func (f *lockingFile) Utimens(atime *time.Time, mtime *time.Time, ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Utimens(atime, mtime)
+	return f.file.Utimens(atime, mtime, ctx)
 }
 
-func (f *lockingFile) Truncate(size uint64) fuse.Status {
+func (f *lockingFile) Truncate(size uint64, ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Truncate(size)
+	return f.file.Truncate(size, ctx)
 }
 
-func (f *lockingFile) Chown(uid uint32, gid uint32) fuse.Status {
+func (f *lockingFile) Chown(uid uint32, gid uint32, ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Chown(uid, gid)
+	return f.file.Chown(uid, gid, ctx)
 }
 
-func (f *lockingFile) Chmod(perms uint32) fuse.Status {
+func (f *lockingFile) Chmod(perms uint32, ctx *fuse.Context) fuse.Status {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Chmod(perms)
+	return f.file.Chmod(perms, ctx)
 }
 
-func (f *lockingFile) Allocate(off uint64, size uint64, mode uint32) (code fuse.Status) {
+func (f *lockingFile) Allocate(off uint64, size uint64, mode uint32, ctx *fuse.Context) (code fuse.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.file.Allocate(off, size, mode)
+	return f.file.Allocate(off, size, mode, ctx)
 }

--- a/fuse/nodefs/memnode.go
+++ b/fuse/nodefs/memnode.go
@@ -162,8 +162,8 @@ func (n *memNodeFile) InnerFile() File {
 	return n.File
 }
 
-func (n *memNodeFile) Flush() fuse.Status {
-	code := n.File.Flush()
+func (n *memNodeFile) Flush(ctx *fuse.Context) fuse.Status {
+	code := n.File.Flush(ctx)
 
 	if !code.Ok() {
 		return code
@@ -205,7 +205,7 @@ func (n *memNode) GetAttr(fi *fuse.Attr, file File, context *fuse.Context) (code
 
 func (n *memNode) Truncate(file File, size uint64, context *fuse.Context) (code fuse.Status) {
 	if file != nil {
-		code = file.Truncate(size)
+		code = file.Truncate(size, context)
 	} else {
 		err := os.Truncate(n.filename(), int64(size))
 		code = fuse.ToStatus(err)

--- a/fuse/pathfs/copy.go
+++ b/fuse/pathfs/copy.go
@@ -16,7 +16,7 @@ func CopyFile(srcFs, destFs FileSystem, srcFile, destFile string, context *fuse.
 		return code
 	}
 	defer src.Release()
-	defer src.Flush()
+	defer src.Flush(context)
 
 	attr, code := srcFs.GetAttr(srcFile, context)
 	if !code.Ok() {
@@ -28,12 +28,12 @@ func CopyFile(srcFs, destFs FileSystem, srcFile, destFile string, context *fuse.
 		return code
 	}
 	defer dst.Release()
-	defer dst.Flush()
+	defer dst.Flush(context)
 
 	buf := make([]byte, 128*(1<<10))
 	off := int64(0)
 	for {
-		res, code := src.Read(buf, off)
+		res, code := src.Read(buf, off, context)
 		if !code.Ok() {
 			return code
 		}
@@ -45,7 +45,7 @@ func CopyFile(srcFs, destFs FileSystem, srcFile, destFile string, context *fuse.
 		if len(data) == 0 {
 			break
 		}
-		n, code := dst.Write(data, off)
+		n, code := dst.Write(data, off, context)
 		if !code.Ok() {
 			return code
 		}

--- a/fuse/test/fsetattr_test.go
+++ b/fuse/test/fsetattr_test.go
@@ -29,7 +29,7 @@ func (f *MutableDataFile) String() string {
 	return "MutableDataFile"
 }
 
-func (f *MutableDataFile) Read(buf []byte, off int64) (fuse.ReadResult, fuse.Status) {
+func (f *MutableDataFile) Read(buf []byte, off int64, ctx *fuse.Context) (fuse.ReadResult, fuse.Status) {
 	end := int(off) + len(buf)
 	if end > len(f.data) {
 		end = len(f.data)
@@ -38,7 +38,7 @@ func (f *MutableDataFile) Read(buf []byte, off int64) (fuse.ReadResult, fuse.Sta
 	return fuse.ReadResultData(f.data[off:end]), fuse.OK
 }
 
-func (f *MutableDataFile) Write(d []byte, off int64) (uint32, fuse.Status) {
+func (f *MutableDataFile) Write(d []byte, off int64, ctx *fuse.Context) (uint32, fuse.Status) {
 	end := int64(len(d)) + off
 	if int(end) > len(f.data) {
 		data := make([]byte, len(f.data), end)
@@ -51,7 +51,7 @@ func (f *MutableDataFile) Write(d []byte, off int64) (uint32, fuse.Status) {
 	return uint32(end - off), fuse.OK
 }
 
-func (f *MutableDataFile) Flush() fuse.Status {
+func (f *MutableDataFile) Flush(ctx *fuse.Context) fuse.Status {
 	return fuse.OK
 }
 
@@ -64,34 +64,34 @@ func (f *MutableDataFile) getAttr(out *fuse.Attr) {
 	out.Size = uint64(len(f.data))
 }
 
-func (f *MutableDataFile) GetAttr(out *fuse.Attr) fuse.Status {
+func (f *MutableDataFile) GetAttr(out *fuse.Attr, ctx *fuse.Context) fuse.Status {
 	f.GetAttrCalled = true
 	f.getAttr(out)
 	return fuse.OK
 }
 
-func (f *MutableDataFile) Utimens(atime *time.Time, mtime *time.Time) fuse.Status {
+func (f *MutableDataFile) Utimens(atime *time.Time, mtime *time.Time, ctx *fuse.Context) fuse.Status {
 	f.Attr.SetTimes(atime, mtime, nil)
 	return fuse.OK
 }
 
-func (f *MutableDataFile) Truncate(size uint64) fuse.Status {
+func (f *MutableDataFile) Truncate(size uint64, ctx *fuse.Context) fuse.Status {
 	f.data = f.data[:size]
 	return fuse.OK
 }
 
-func (f *MutableDataFile) Chown(uid uint32, gid uint32) fuse.Status {
+func (f *MutableDataFile) Chown(uid uint32, gid uint32, ctx *fuse.Context) fuse.Status {
 	f.Attr.Uid = uid
 	f.Attr.Gid = gid
 	return fuse.OK
 }
 
-func (f *MutableDataFile) Chmod(perms uint32) fuse.Status {
+func (f *MutableDataFile) Chmod(perms uint32, ctx *fuse.Context) fuse.Status {
 	f.Attr.Mode = (f.Attr.Mode &^ 07777) | perms
 	return fuse.OK
 }
 
-func (f *MutableDataFile) Fsync(flags int) fuse.Status {
+func (f *MutableDataFile) Fsync(flags int, ctx *fuse.Context) fuse.Status {
 	f.FsyncCalled = true
 	return fuse.OK
 }


### PR DESCRIPTION
[ I know this won't probably be accepted because it has to change nodefs API and nodefs is deprecated. I decided to share anyway since this is general functionality that might be useful ]


So that e.g. File.Read could be canceled.

This is already so in fs/ package. However WCFS in Wendelin.core still
uses older nodefs package, and for now it was faster to teach old
nodefs.File about cancel propagation.

References:

https://lab.nexedi.com/kirr/wendelin.core/commit/b17aeb8c
https://lab.nexedi.com/kirr/wendelin.core/commit/f05271b1
https://lab.nexedi.com/kirr/wendelin.core/commit/5ba816da
https://lab.nexedi.com/kirr/go123/commit/7ad867a3
https://lab.nexedi.com/kirr/go123/commit/0bdac628
https://lab.nexedi.com/kirr/go123/commit/d2dc6c09