### PR TITLE
Fix statfs.Bsize on Darwin

### DIFF
--- a/fuse/types_darwin.go
+++ b/fuse/types_darwin.go
@@ -151,16 +151,6 @@ func (s *StatfsOut) FromStatfsT(statfs *syscall.Statfs_t) {
 	s.Bavail = statfs.Bavail
 	s.Files = statfs.Files
 	s.Ffree = statfs.Ffree
-	s.Bsize = uint32(statfs.Iosize) // Iosize translates to Bsize: the optimal transfer size.
-	s.Frsize = s.Bsize              // Bsize translates to Frsize: the minimum transfer size.
-
-	// The block counts are in units of statfs.Bsize.
-	// If s.Bsize != statfs.Bsize, we have to recalculate the block counts
-	// accordingly (s.Bsize is usually 256*statfs.Bsize).
-	if s.Bsize > statfs.Bsize {
-		adj := uint64(s.Bsize / statfs.Bsize)
-		s.Blocks /= adj
-		s.Bfree /= adj
-		s.Bavail /= adj
-	}
+	s.Bsize = uint32(statfs.Bsize)
+	s.Frsize = uint32(statfs.Bsize)
 }


### PR DESCRIPTION
Fixed mapping in FromStatfsT for Darwin, previously it resulted into incorrect reporting of total and free space in the "df" and "du" commands

https://github.com/hanwen/go-fuse/pull/275 was fixing incorrectly showing free and available space based on block count. But this number also affects statistics reported by du. Better is to map both to Bsize and then all calculations are correct and there is no need to recalculate block count on the device.

https://opensource.apple.com/source/file_cmds/file_cmds-272.250.1/du/du.c.auto.html
`howmany(p->fts_statp->st_blocks, blocksize)`

And according to http://man7.org/linux/man-pages/man2/stat.2.html
`blkcnt_t  st_blocks;      /* Number of 512B blocks allocated */`

Which creates a mismatch.

Currently:
```
ls -l
total 4096
-rw-r--r--  1 x  x  1024 *** test
-rw-r--r--  1 x  x     0 *** test2
-rw-r--r--  1 x  x     2 *** test3

du *
2048	test
0	test2
2048	test3
```
So it thinks, that the file occupies 1 MB or 2048 512B blocks.

After the change:
```
ls -l
total 4096
-rw-r--r--  1 x  x  1024 *** test
-rw-r--r--  1 x  x     0 *** test2
-rw-r--r--  1 x  x     2 *** test3

du *
8	test
0	test2
8	test3
```
or 4K each.

It is also a follow up for https://github.com/hanwen/go-fuse/pull/213