### PR TITLE
batch forget: fix missing return to handle malformed input data

### DIFF
--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -303,6 +303,7 @@ func doBatchForget(server *Server, req *request) {
 		// We have no return value to complain, so log an error.
 		log.Printf("Too few bytes for batch forget. Got %d bytes, want %d (%d entries)",
 			len(req.arg), wantBytes, in.Count)
+		return
 	}
 
 	h := &reflect.SliceHeader{


### PR DESCRIPTION
The `doBatchForget` function consumes a slice of `struct _ForgetOne` objects, and that array is created by type-casting the `req.arg` byte slice using `unsafe.Pointer`. The length of the new slice is taken from the request as well (`req.inData.Count`), and is therefore user-supplied.

If a malicious data input were to specify a `Count` not appropriate for the slice length of `req.arg`, iterating over the `forgets` slice will potentially read from memory outside of the `req.arg` slice.

Now, the `doBatchForget` function already checks if the input data is long enough for the requested `Count` with `if uintptr(len(req.arg)) < wantBytes`, but other than logging a message the function doesn't do anything. It continues to create the `forgets` slice with wrong boundaries.

```go
func doBatchForget(server *Server, req *request) {
	in := (*_BatchForgetIn)(req.inData)
	wantBytes := uintptr(in.Count) * unsafe.Sizeof(_ForgetOne{})
	if uintptr(len(req.arg)) < wantBytes {
		// We have no return value to complain, so log an error.
		log.Printf("Too few bytes for batch forget. Got %d bytes, want %d (%d entries)",
			len(req.arg), wantBytes, in.Count)
                // nothing is done here
	}
```

This PR proposes to add a `return` statement to terminate the function if there is too few data.

A different fix would be to use a lower length for `forgets` than `Count`, i.e. the minimum of `Count` and the maximum available `_ForgetOne` objects based on the received data length. I prepared this as well, so hit me up for that code if you prefer!

This is a very-low-impact threat model because the input data is generated by the kernel, not a malicious user-space program, but it might still affect possible fuse proxy architectures. A successful exploit might turn this into an information leak. I have a simple proof of concept for this if you are interested. In the meantime, I suggest adding the `return` :sparkles: 