### PR TITLE
fuse: support the new macFUSE mount protocol

### DIFF
--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -68,6 +68,7 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 	}
 
 	go func() {
+		// wait inside a goroutine or otherwise it would block forever for unknown reasons
 		if err := cmd.Wait(); err != nil {
 			err = fmt.Errorf("mount_osxfusefs failed: %v. Stderr: %s, Stdout: %s",
 				err, errOut.String(), out.String())

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -9,89 +9,124 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"syscall"
+	"unsafe"
 )
 
-func openFUSEDevice() (*os.File, error) {
-	fs, err := filepath.Glob("/dev/osxfuse*")
+func unixgramSocketpair() (l, r *os.File, err error) {
+	fd, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, os.NewSyscallError("socketpair",
+			err.(syscall.Errno))
 	}
-	if len(fs) == 0 {
-		bin := oldLoadBin
-		if _, err := os.Stat(newLoadBin); err == nil {
-			bin = newLoadBin
-		}
-
-		cmd := exec.Command(bin)
-		if err := cmd.Run(); err != nil {
-			return nil, err
-		}
-		fs, err = filepath.Glob("/dev/osxfuse*")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for _, fn := range fs {
-		f, err := os.OpenFile(fn, os.O_RDWR, 0)
-		if err != nil {
-			continue
-		}
-		return f, nil
-	}
-
-	return nil, fmt.Errorf("all FUSE devices busy")
+	l = os.NewFile(uintptr(fd[0]), "socketpair-half1")
+	r = os.NewFile(uintptr(fd[1]), "socketpair-half2")
+	return
 }
 
-const oldLoadBin = "/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs"
-const newLoadBin = "/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse"
-
-const oldMountBin = "/Library/Filesystems/osxfusefs.fs/Support/mount_osxfusefs"
-const newMountBin = "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse"
-
+// Create a FUSE FS on the specified mount point.  The returned
+// mount point is always absolute.
 func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, err error) {
-	f, err := openFUSEDevice()
+	local, remote, err := unixgramSocketpair()
+	if err != nil {
+		return
+	}
+
+	defer local.Close()
+	defer remote.Close()
+
+	bin, err := fusermountBinary()
 	if err != nil {
 		return 0, err
 	}
 
-	bin := oldMountBin
-	if _, err := os.Stat(newMountBin); err == nil {
-		bin = newMountBin
-	}
-
-	cmd := exec.Command(bin, "-o", strings.Join(opts.optionsStrings(), ","), "-o", fmt.Sprintf("iosize=%d", opts.MaxWrite), "3", mountPoint)
-	cmd.ExtraFiles = []*os.File{f}
-	cmd.Env = append(os.Environ(), "MOUNT_FUSEFS_CALL_BY_LIB=", "MOUNT_OSXFUSE_CALL_BY_LIB=",
-		"MOUNT_OSXFUSE_DAEMON_PATH="+os.Args[0],
-		"MOUNT_FUSEFS_DAEMON_PATH="+os.Args[0])
+	cmd := exec.Command(bin,
+		"-o", strings.Join(opts.optionsStrings(), ","),
+		"-o", fmt.Sprintf("iosize=%d", opts.MaxWrite),
+		mountPoint)
+	cmd.ExtraFiles = []*os.File{remote} // fd would be (index + 3)
+	cmd.Env = append(os.Environ(),
+		"_FUSE_CALL_BY_LIB=",
+		"_FUSE_DAEMON_PATH="+os.Args[0],
+		"_FUSE_COMMFD=3",
+		"_FUSE_COMMVERS=2",
+		"MOUNT_OSXFUSE_CALL_BY_LIB=",
+		"MOUNT_OSXFUSE_DAEMON_PATH="+os.Args[0])
 
 	var out, errOut bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errOut
 
-	if err := cmd.Start(); err != nil {
-		f.Close()
-		return 0, err
+	if err = cmd.Start(); err != nil {
+		return
 	}
+
+	fd, err = getConnection(local)
+	if err != nil {
+		return -1, err
+	}
+
 	go func() {
-		err := cmd.Wait()
-		if err != nil {
-			err = fmt.Errorf("mount_osxfusefs failed: %v. Stderr: %s, Stdout: %s", err, errOut.String(), out.String())
+		if err := cmd.Wait(); err != nil {
+			err = fmt.Errorf("mount_osxfusefs failed: %v. Stderr: %s, Stdout: %s",
+				err, errOut.String(), out.String())
 		}
 
 		ready <- err
 		close(ready)
 	}()
 
-	// The finalizer for f will close its fd so we return a dup.
-	defer f.Close()
-	return syscall.Dup(int(f.Fd()))
+	// golang sets CLOEXEC on file descriptors when they are
+	// acquired through normal operations (e.g. open).
+	// Buf for fd, we have to set CLOEXEC manually
+	syscall.CloseOnExec(fd)
+
+	return fd, err
 }
 
 func unmount(dir string, opts *MountOptions) error {
 	return syscall.Unmount(dir, 0)
+}
+
+func getConnection(local *os.File) (int, error) {
+	var data [4]byte
+	control := make([]byte, 4*256)
+
+	// n, oobn, recvflags, from, errno  - todo: error checking.
+	_, oobn, _, _,
+		err := syscall.Recvmsg(
+		int(local.Fd()), data[:], control[:], 0)
+	if err != nil {
+		return 0, err
+	}
+
+	message := *(*syscall.Cmsghdr)(unsafe.Pointer(&control[0]))
+	fd := *(*int32)(unsafe.Pointer(uintptr(unsafe.Pointer(&control[0])) + syscall.SizeofCmsghdr))
+
+	if message.Type != syscall.SCM_RIGHTS {
+		return 0, fmt.Errorf("getConnection: recvmsg returned wrong control type: %d", message.Type)
+	}
+	if oobn <= syscall.SizeofCmsghdr {
+		return 0, fmt.Errorf("getConnection: too short control message. Length: %d", oobn)
+	}
+	if fd < 0 {
+		return 0, fmt.Errorf("getConnection: fd < 0: %d", fd)
+	}
+	return int(fd), nil
+}
+
+func fusermountBinary() (string, error) {
+	binPaths := []string{
+		"/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse",
+		"/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse",
+	}
+
+	for _, path := range binPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("no FUSE mount utility found")
 }


### PR DESCRIPTION
Closes #379.

~This is still a work in progress.~

# Changes

- adds support for the new style mount process detailed in https://github.com/osxfuse/fuse/commit/8afa4eabdddb7fc9e810f43666462c4d2451925f
- drops support for the old style mount process
- support paths and env vars renamed in the osxfuse -> macFUSE rebranding changes