### PR TITLE
fs: panic on mknod if NodeMknoder isn't implemented

### DIFF
--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -418,6 +418,8 @@ func (b *rawBridge) Mknod(cancel <-chan struct{}, input *fuse.MknodIn, name stri
 	var errno syscall.Errno
 	if mops, ok := parent.ops.(NodeMknoder); ok {
 		child, errno = mops.Mknod(&fuse.Context{Caller: input.Caller, Cancel: cancel}, name, input.Mode, input.Rdev, out)
+	} else {
+		return fuse.ENOTSUP
 	}
 
 	if errno != 0 {


### PR DESCRIPTION
`rawBridge.Mknod` currently panics if `NodeMknoder` isn't implemented. This PR makes it return `ENOTSUP` instead.