### PR TITLE
RFC: Reduce memory usage by recreating big maps

### DIFF
--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -7,6 +7,7 @@ package fs
 import (
 	"context"
 	"log"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -81,6 +82,12 @@ type rawBridge struct {
 	kernelNodeIds map[uint64]*Inode
 	// nextNodeID is the next free NodeID. Increment after copying the value.
 	nextNodeId uint64
+	// nodeCountHigh records the highest number of entries we had in the
+	// kernelNodeIds map.
+	// As the size of stableAttrs tracks kernelNodeIds (+- a few entries due to
+	// concurrent FORGETs, LOOKUPs, and the fixed NodeID 1), this is also a good
+	// estimate for stableAttrs.
+	nodeCountHigh int
 
 	files     []*fileEntry
 	freeFiles []uint32
@@ -201,6 +208,9 @@ func (b *rawBridge) addNewChild(parent *Inode, name string, child *Inode, file F
 	child.changeCounter++
 
 	b.kernelNodeIds[child.nodeId] = child
+	if len(b.kernelNodeIds) > b.nodeCountHigh {
+		b.nodeCountHigh = len(b.kernelNodeIds)
+	}
 	// Any node that might be there is overwritten - it is obsolete now
 	b.stableAttrs[id] = child
 	if file != nil {
@@ -465,7 +475,47 @@ func (b *rawBridge) Create(cancel <-chan struct{}, input *fuse.CreateIn, name st
 
 func (b *rawBridge) Forget(nodeid, nlookup uint64) {
 	n, _ := b.inode(nodeid, 0)
-	n.removeRef(nlookup, false)
+	forgotten, _ := n.removeRef(nlookup, false)
+
+	if forgotten {
+		b.compactMemory()
+	}
+}
+
+// compactMemory tries to free memory that was previously used by forgotten
+// nodes.
+//
+// Maps do not free all memory when elements get deleted
+// ( https://github.com/golang/go/issues/20135 ).
+// As a workaround, we recreate our two big maps (stableAttrs & kernelNodeIds)
+// every time they have shrunk dramatically (100 x smaller).
+// In this case, `nodeCountHigh` is reset to the new (smaller) size.
+func (b *rawBridge) compactMemory() {
+	b.mu.Lock()
+
+	if b.nodeCountHigh <= len(b.kernelNodeIds)*100 {
+		b.mu.Unlock()
+		return
+	}
+
+	tmpStableAttrs := make(map[StableAttr]*Inode)
+	for i, v := range b.stableAttrs {
+		tmpStableAttrs[i] = v
+	}
+	b.stableAttrs = tmpStableAttrs
+
+	tmpKernelNodeIds := make(map[uint64]*Inode)
+	for i, v := range b.kernelNodeIds {
+		tmpKernelNodeIds[i] = v
+	}
+	b.kernelNodeIds = tmpKernelNodeIds
+
+	b.nodeCountHigh = len(b.kernelNodeIds)
+
+	b.mu.Unlock()
+
+	// Run outside b.mu
+	debug.FreeOSMemory()
 }
 
 func (b *rawBridge) SetDebug(debug bool) {}

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -390,8 +390,8 @@ func (n *Inode) removeRef(nlookup uint64, dropPersistence bool) (forgotten bool,
 	n.bridge.mu.Lock()
 	if n.lookupCount == 0 {
 		forgotten = true
-		// Dropping the node from inoMap guarantees that no new references to this node are
-		// handed out to the kernel, hence we can also safely delete it from nodeidMap.
+		// Dropping the node from stableAttrs guarantees that no new references to this node are
+		// handed out to the kernel, hence we can also safely delete it from kernelNodeIds.
 		delete(n.bridge.stableAttrs, n.stableAttr)
 		delete(n.bridge.kernelNodeIds, n.nodeId)
 	}


### PR DESCRIPTION
Posting here as a PR before going through gerrithub because I'd like to know what you think about this.

When we know a lot of inodes the kernelNodeIds & stableAttrs maps grow as needed.
The kernel will send FORGET under memory pressure (simulated here via `echo 3 | sudo tee /proc/sys/vm/drop_caches`), but the maps still take a lot of memory because of https://github.com/golang/go/issues/20135 .

This is an attempt to mitigate this in response to a [user who runs gocryptfs on a 2 GB ARMv7 device](https://github.com/rfjakob/gocryptfs/issues/569).

Commit message follows:

-------------

```
fs: recreate kernelNodeIds & stableAttrs when they shrink

Maps do not free all memory when elements get deleted
( https://github.com/golang/go/issues/20135 ).

As a workaround, we recreate our two big maps (kernelNodeIds & stableAttrs)
when they have shrunk dramatically (100 x smaller).

Benchmarkung with loopback (go version go1.16.2 linux/amd64) shows:

Before this change:

State              VmRSS (kiB)
-----              -----------
Fresh mount          4000
ls -R 500k files   271100
after drop_cache   336448
wait ~ 3 minutes   101588

After:

State              VmRSS (kiB)
-----              -----------
Fresh mount          4012
ls -R 500k files   271100
after drop_cache    31528

Results for gocryptfs are similar.

Fixes: https://github.com/rfjakob/gocryptfs/issues/569
Change-Id: Idcae1ab953270516735839a034d586717647b8db
```