### PR TITLE
Add an option to enable kernel writeback cache

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -180,6 +180,9 @@ type MountOptions struct {
 	// in https://github.com/libfuse/libfuse/blob/master/include/fuse_common.h
 	// for details.
 	EnableAcl bool
+
+	// EnableWriteback enables kernel writeback cache.
+	EnableWriteback bool
 }
 
 // RawFileSystem is an interface close to the FUSE wire protocol.

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -99,6 +99,10 @@ func doInit(server *Server, req *request) {
 		server.kernelSettings.Flags |= CAP_POSIX_ACL
 	}
 
+	if server.opts.EnableWriteback {
+		server.kernelSettings.Flags |= CAP_WRITEBACK_CACHE
+	}
+
 	dataCacheMode := input.Flags & CAP_AUTO_INVAL_DATA
 	if server.opts.ExplicitDataCacheControl {
 		// we don't want CAP_AUTO_INVAL_DATA even if we cannot go into fully explicit mode


### PR DESCRIPTION
The kernel writeback cache (since Linux 3.15) is useful to combine small write together to boost the performance.

We may not enable that by default, but we should have a way to enable it.