### PR TITLE
Fix IOCTL to return the error allowed by overlayfs

### DIFF
--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"reflect"
 	"runtime"
+	"syscall"
 	"time"
 	"unsafe"
 )
@@ -442,7 +443,7 @@ func doStatFs(server *Server, req *request) {
 }
 
 func doIoctl(server *Server, req *request) {
-	req.status = ENOSYS
+	req.status = Status(syscall.ENOTTY)
 }
 
 func doDestroy(server *Server, req *request) {


### PR DESCRIPTION
Fixes https://github.com/hanwen/go-fuse/issues/406

Since kernel 5.15, IOCTL returning ENOSYS is not allowed in overlayfs lowerdirs.
https://github.com/torvalds/linux/commit/72db82115d2bdfbfba8b15a92d91872cfe1b40c6

This commit fixes this issue by returning ENOTTY which is allowed since
https://github.com/torvalds/linux/commit/5b0a414d06c3ed2097e32ef7944a4abb644b89bd

This fixes the issue in 5.16 and later but not in 5.15.
To fully fix this, maybe we'll need to implement IOCTL.

