### PR TITLE
Fix double lock for Getattr() on darwin

### DIFF
--- a/fs/files.go
+++ b/fs/files.go
@@ -214,6 +214,10 @@ func (f *loopbackFile) setAttr(ctx context.Context, in *fuse.SetAttrIn) syscall.
 func (f *loopbackFile) Getattr(ctx context.Context, a *fuse.AttrOut) syscall.Errno {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	return f.getattr(ctx, a)
+}
+
+func (f *loopbackFile) getattr(ctx context.Context, a *fuse.AttrOut) syscall.Errno {
 	st := syscall.Stat_t{}
 	err := syscall.Fstat(f.fd, &st)
 	if err != nil {

--- a/fs/loopback_darwin.go
+++ b/fs/loopback_darwin.go
@@ -101,7 +101,7 @@ func timeToTimeval(t *time.Time) syscall.Timeval {
 func (f *loopbackFile) utimens(a *time.Time, m *time.Time) syscall.Errno {
 	var attr fuse.AttrOut
 	if a == nil || m == nil {
-		errno := f.Getattr(context.Background(), &attr)
+		errno := f.getattr(context.Background(), &attr)
 		if errno != 0 {
 			return errno
 		}


### PR DESCRIPTION
This commit fixes an issue where Setattr(), which takes a lock, and then calls utimens() which calls Getattr(), which takes the same lock again. This causes the loopback file system to hang indefinitely.

The first lock in `setattr()` occurs [here](https://github.com/benbjohnson/go-fuse/blob/611fe8125e3bf407b10dc949cbcb1dc48552674e/fs/files.go#L199) and the next lock occurs [here](https://github.com/benbjohnson/go-fuse/blob/611fe8125e3bf407b10dc949cbcb1dc48552674e/fs/files.go#L215-L216).

Here's the stack trace for when the double lock occurs:

```
sync.runtime_SemacquireMutex(0x10a23cc, 0x0, 0xc00021a500)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc00021cc80)
	/usr/local/Cellar/go/1.17.6/libexec/src/sync/mutex.go:138 +0x165
sync.(*Mutex).Lock(...)
	/usr/local/Cellar/go/1.17.6/libexec/src/sync/mutex.go:81
github.com/hanwen/go-fuse/v2/fs.(*loopbackFile).Getattr(0xc000307501, {0xc000182cb8, 0x10a710c}, 0xc000182c08)
	/src/hanwen/go-fuse/fs/files.go:215 +0x74
github.com/hanwen/go-fuse/v2/fs.(*loopbackFile).utimens(0xc00021cc80, 0xc000182cd8, 0x0)
	/src/hanwen/go-fuse/fs/loopback_darwin.go:105 +0x7d
github.com/hanwen/go-fuse/v2/fs.(*loopbackFile).setAttr(0xc00021cc80, {0x100bf34, 0x1106220}, 0xc0003161c0)
	/src/hanwen/go-fuse/fs/files.go:199 +0x205
github.com/hanwen/go-fuse/v2/fs.(*loopbackFile).Setattr(0xc00022a1b0, {0x114fce8, 0xc000208d20}, 0xc000280000, 0x0)
	/src/hanwen/go-fuse/fs/files.go:151 +0x2d
github.com/hanwen/go-fuse/v2/fs.(*LoopbackNode).Setattr(0xc0000ec000, {0x114fce8, 0xc000208d20}, {0x1118740, 0xc00021cc80}, 0xc0003161c0, 0xc000190a08)
	/src/hanwen/go-fuse/fs/loopback.go:334 +0x302
github.com/hanwen/go-fuse/v2/fs.(*rawBridge).SetAttr(0xc0000b6000, 0xc00018e180, 0xc0003161c0, 0xc000190a08)
	/src/hanwen/go-fuse/fs/bridge.go:578 +0xfa
github.com/hanwen/go-fuse/v2/fuse.doSetattr(0xc000182f78, 0xc000190900)
	/src/hanwen/go-fuse/fuse/opcode.go:196 +0x55
github.com/hanwen/go-fuse/v2/fuse.(*Server).handleRequest(0xc0000f0000, 0xc000190900)
	/src/hanwen/go-fuse/fuse/server.go:507 +0x1f3
created by github.com/hanwen/go-fuse/v2/fuse.(*Server).loop
	/src/hanwen/go-fuse/fuse/server.go:478 +0xfd
```