### PR TITLE
Make pollHack work on read-only mounts on Darwin

### DIFF
--- a/fuse/poll_darwin.go
+++ b/fuse/poll_darwin.go
@@ -32,7 +32,7 @@ func pollHack(mountPoint string) error {
 		POLLHUP   = 0x10
 	)
 
-	fd, err := syscall.Open(filepath.Join(mountPoint, pollHackName), syscall.O_CREAT|syscall.O_TRUNC|syscall.O_RDWR, 0644)
+	fd, err := syscall.Open(filepath.Join(mountPoint, pollHackName), syscall.O_RDONLY, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ports commit fee50bf01cd60f66c82493761756b2c345a86aa3 to `poll_darwin.go` in order to allow read-only mounts on Darwin as well.

Fixes https://github.com/rfjakob/gocryptfs/issues/595 where we can't use `gocryptfs -ro` or `gocryptfs -reverse` on macOS because go-fuse tries to write to the read-only mountpoint during initial mount.

Cheers!

Edit: signed the CLA and re-pushed so automated checks pass

Edit: potentially fixes #373