### PR TITLE
Make OSXFUSE handle timeouts the same way as Linux

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -262,6 +262,13 @@ func (o *MountOptions) optionsStrings() []string {
 		r = append(r, "subtype="+o.Name)
 	}
 
+	// OSXFUSE applies a 60-second timeout for file operations. This
+	// is inconsistent with how FUSE works on Linux, where operations
+	// last as long as the daemon is willing to let them run.
+	if runtime.GOOS == "darwin" {
+		r = append(r, "daemon_timeout=0")
+	}
+
 	return r
 }
 


### PR DESCRIPTION
OSXFUSE applies a 60-second timeout for file operations. This
is inconsistent with how FUSE works on Linux, where operations
last as long as the daemon is willing to let them run.

This has been running in production for ~2 years.

closes #331 