### PR TITLE
Expose the telldir/seekdir cookies in the FS api.

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -331,8 +331,8 @@ type RawFileSystem interface {
 
 	// Directory handling
 	OpenDir(cancel <-chan struct{}, input *OpenIn, out *OpenOut) (status Status)
-	ReadDir(cancel <-chan struct{}, input *ReadIn, out *DirEntryList) Status
-	ReadDirPlus(cancel <-chan struct{}, input *ReadIn, out *DirEntryList) Status
+	ReadDir(cancel <-chan struct{}, input *ReadIn, out ReadDirEntryList) Status
+	ReadDirPlus(cancel <-chan struct{}, input *ReadIn, out ReadDirPlusEntryList) Status
 	ReleaseDir(input *ReleaseIn)
 	FsyncDir(cancel <-chan struct{}, input *FsyncIn) (code Status)
 

--- a/fuse/defaultraw.go
+++ b/fuse/defaultraw.go
@@ -140,11 +140,11 @@ func (fs *defaultRawFileSystem) Fsync(cancel <-chan struct{}, input *FsyncIn) (c
 	return ENOSYS
 }
 
-func (fs *defaultRawFileSystem) ReadDir(cancel <-chan struct{}, input *ReadIn, l *DirEntryList) Status {
+func (fs *defaultRawFileSystem) ReadDir(cancel <-chan struct{}, input *ReadIn, l ReadDirEntryList) Status {
 	return ENOSYS
 }
 
-func (fs *defaultRawFileSystem) ReadDirPlus(cancel <-chan struct{}, input *ReadIn, l *DirEntryList) Status {
+func (fs *defaultRawFileSystem) ReadDirPlus(cancel <-chan struct{}, input *ReadIn, l ReadDirPlusEntryList) Status {
 	return ENOSYS
 }
 

--- a/fuse/nodefs/dir.go
+++ b/fuse/nodefs/dir.go
@@ -22,7 +22,7 @@ type connectorDir struct {
 	stream []fuse.DirEntry
 }
 
-func (d *connectorDir) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out *fuse.DirEntryList) (code fuse.Status) {
+func (d *connectorDir) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out fuse.ReadDirEntryList) (code fuse.Status) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -54,7 +54,7 @@ func (d *connectorDir) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out *
 			log.Printf("got empty directory entry, mode %o.", e.Mode)
 			continue
 		}
-		ok := out.AddDirEntry(e)
+		ok := out.AddDirEntry(e, input.Offset+1)
 		if !ok {
 			break
 		}
@@ -62,7 +62,7 @@ func (d *connectorDir) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out *
 	return fuse.OK
 }
 
-func (d *connectorDir) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, out *fuse.DirEntryList) (code fuse.Status) {
+func (d *connectorDir) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, out fuse.ReadDirPlusEntryList) (code fuse.Status) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -91,7 +91,7 @@ func (d *connectorDir) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, o
 
 		// we have to be sure entry will fit if we try to add
 		// it, or we'll mess up the lookup counts.
-		entryDest := out.AddDirLookupEntry(e)
+		entryDest := out.AddDirLookupEntry(e, input.Offset+1)
 		if entryDest == nil {
 			break
 		}
@@ -108,6 +108,6 @@ func (d *connectorDir) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, o
 }
 
 type rawDir interface {
-	ReadDir(out *fuse.DirEntryList, input *fuse.ReadIn, c *fuse.Context) fuse.Status
-	ReadDirPlus(out *fuse.DirEntryList, input *fuse.ReadIn, c *fuse.Context) fuse.Status
+	ReadDir(out fuse.ReadDirEntryList, input *fuse.ReadIn, c *fuse.Context) fuse.Status
+	ReadDirPlus(out fuse.ReadDirPlusEntryList, input *fuse.ReadIn, c *fuse.Context) fuse.Status
 }

--- a/fuse/nodefs/fsops.go
+++ b/fuse/nodefs/fsops.go
@@ -172,13 +172,13 @@ func (c *rawBridge) OpenDir(cancel <-chan struct{}, input *fuse.OpenIn, out *fus
 	return fuse.OK
 }
 
-func (c *rawBridge) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out *fuse.DirEntryList) fuse.Status {
+func (c *rawBridge) ReadDir(cancel <-chan struct{}, input *fuse.ReadIn, out fuse.ReadDirEntryList) fuse.Status {
 	node := c.toInode(input.NodeId)
 	opened := node.mount.getOpenedFile(input.Fh)
 	return opened.dir.ReadDir(cancel, input, out)
 }
 
-func (c *rawBridge) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, out *fuse.DirEntryList) fuse.Status {
+func (c *rawBridge) ReadDirPlus(cancel <-chan struct{}, input *fuse.ReadIn, out fuse.ReadDirPlusEntryList) fuse.Status {
 	node := c.toInode(input.NodeId)
 	opened := node.mount.getOpenedFile(input.Fh)
 	return opened.dir.ReadDirPlus(cancel, input, out)

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -168,7 +168,7 @@ func doCreate(server *Server, req *request) {
 func doReadDir(server *Server, req *request) {
 	in := (*ReadIn)(req.inData)
 	buf := server.allocOut(req, in.Size)
-	out := NewDirEntryList(buf, uint64(in.Offset))
+	out := NewDirEntryList(buf)
 
 	code := server.fileSystem.ReadDir(req.cancel, in, out)
 	req.flatData = out.bytes()
@@ -178,7 +178,7 @@ func doReadDir(server *Server, req *request) {
 func doReadDirPlus(server *Server, req *request) {
 	in := (*ReadIn)(req.inData)
 	buf := server.allocOut(req, in.Size)
-	out := NewDirEntryList(buf, uint64(in.Offset))
+	out := NewDirEntryList(buf)
 
 	code := server.fileSystem.ReadDirPlus(req.cancel, in, out)
 	req.flatData = out.bytes()


### PR DESCRIPTION
Also use interfaces for ReadDir(Plus)EntryList rather than structs to
allow for easier testing.

Exposing the cookies allows users to take full control which allows them
to write POSIX correct implementations. Additionally, this allows to
forward the cookies to an underlying implementation.