### PR TITLE
fix sync.Pool leak

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -305,9 +305,6 @@ func handleEINTR(fn func() error) (err error) {
 // Returns a new request, or error. In case exitIdle is given, returns
 // nil, OK if we have too many readers already.
 func (ms *Server) readRequest(exitIdle bool) (req *request, code Status) {
-	req = ms.reqPool.Get().(*request)
-	dest := ms.readPool.Get().([]byte)
-
 	ms.reqMu.Lock()
 	if ms.reqReaders > ms.maxReaders {
 		ms.reqMu.Unlock()
@@ -315,6 +312,9 @@ func (ms *Server) readRequest(exitIdle bool) (req *request, code Status) {
 	}
 	ms.reqReaders++
 	ms.reqMu.Unlock()
+
+	req = ms.reqPool.Get().(*request)
+	dest := ms.readPool.Get().([]byte)
 
 	var n int
 	err := handleEINTR(func() error {


### PR DESCRIPTION
I find sync.Pool leak in go-fuse server, which will trigger gc frequently and lead to high cpu usage. 
and I also find that increase max readers can improve throughput is mainly because of less sync.Pool leak.

`env:  Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz  (8core 16procs)`
`go test -bench="BenchmarkGoFuseRead" -benchmem`



<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

version | readers | result
-- | -- | --
old | 2 (default) | 10992             92501 ns/op        22671.71 MB/s          536981 B/op             196 allocs/op
  | 4 | 19068             57959 ns/op        36183.44 MB/s          151877 B/op             170 allocs/op
  | 8 | 27729             43796 ns/op        47884.39 MB/s           29068 B/op             162 allocs/op
  | 16 | 28674             41403 ns/op        50651.65 MB/s            6704 B/op             160 allocs/op
fixed | 2 | 23667             46589 ns/op        45014.20 MB/s            5357 B/op             167 allocs/op
  | 4 | 27753             42327 ns/op        49546.77 MB/s            4999 B/op             161 allocs/op
  | 8 | 29648             40806 ns/op        51392.81 MB/s            4904 B/op             160 allocs/op
  | 16 | 29389             40763 ns/op        51447.07 MB/s            4848 B/op             160 allocs/op

</div>


- high cpu usage because of sync.Pool leak
![02961ba4-32a3-423e-b1b3-087cb4aba941](https://user-images.githubusercontent.com/6017354/192079506-b1a58267-60d1-4029-ac2f-920ddcbfe3ad.png)
