### PR TITLE
Make ReadDirPlus configurable

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -229,6 +229,11 @@ type MountOptions struct {
 	// in https://github.com/libfuse/libfuse/blob/master/include/fuse_common.h
 	// for details.
 	EnableAcl bool
+
+	// Disable ReadDirPlus capability so ReadDir is used instead. Simple 
+	// directory queries (i.e. 'ls' without '-l') can be faster with 
+	// ReadDir, as no per-file stat calls are needed
+	DisableReadDirPlus bool
 }
 
 // RawFileSystem is an interface close to the FUSE wire protocol.

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -103,6 +103,10 @@ func doInit(server *Server, req *request) {
 		// Clear CAP_ASYNC_READ
 		server.kernelSettings.Flags &= ^uint32(CAP_ASYNC_READ)
 	}
+	if server.opts.DisableReadDirPlus {
+		// Clear CAP_READDIRPLUS
+		server.kernelSettings.Flags &= ^uint32(CAP_READDIRPLUS)
+	}
 
 	dataCacheMode := input.Flags & CAP_AUTO_INVAL_DATA
 	if server.opts.ExplicitDataCacheControl {


### PR DESCRIPTION
When ReadDirPlus is enabled, the FUSE fs has to gather a lot of additional data for every file even if it won't be used (for example when the user is doing and 'ls' or a large glob). This can cause performance problems, so it should be possible to switch to the simple ReadDir behavior for file systems where this is a bottleneck.
