### PR TITLE
Export unmount function for Linux and Darwin

### DIFF
--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -86,7 +86,7 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 	return fd, err
 }
 
-func unmount(dir string, opts *MountOptions) error {
+func Unmount(dir string, opts *MountOptions) error {
 	return syscall.Unmount(dir, 0)
 }
 

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -172,7 +172,7 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 	return fd, err
 }
 
-func unmount(mountPoint string, opts *MountOptions) (err error) {
+func Unmount(mountPoint string, opts *MountOptions) (err error) {
 	if opts.DirectMount || opts.DirectMountStrict {
 		// Attempt to directly unmount, if fails fallback to fusermount method
 		err := syscall.Unmount(mountPoint, 0)

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -133,7 +133,7 @@ func (ms *Server) Unmount() (err error) {
 	}
 	delay := time.Duration(0)
 	for try := 0; try < 5; try++ {
-		err = unmount(ms.mountPoint, ms.opts)
+		err = Unmount(ms.mountPoint, ms.opts)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
This PR renames the `unmount` function in the `fuse` package to `Unmount`, in order to make it accessible to users of the package.

Fixes #455