### PR TITLE
Add option for lazy unmount

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -279,6 +279,10 @@ type MountOptions struct {
 	// directory queries (i.e. 'ls' without '-l') can be faster with
 	// ReadDir, as no per-file stat calls are needed
 	DisableReadDirPlus bool
+
+	// LazyUnmount is used to calling fusermount with -z flag which make unmount
+	// works even if resource is still busy
+	LazyUnmount bool
 }
 
 // RawFileSystem is an interface close to the FUSE wire protocol.

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -191,7 +191,7 @@ func unmount(mountPoint string, opts *MountOptions) (err error) {
 	errBuf := bytes.Buffer{}
 	args := []string{"-u", mountPoint}
 	if opts.LazyUnmount {
-		args = append(args, "-z")
+		args[0] = "-uz"
 	}
 	cmd := exec.Command(bin, args...)
 	cmd.Stderr = &errBuf

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -189,7 +189,11 @@ func unmount(mountPoint string, opts *MountOptions) (err error) {
 		return err
 	}
 	errBuf := bytes.Buffer{}
-	cmd := exec.Command(bin, "-u", mountPoint)
+	args := []string{"-u", mountPoint}
+	if opts.LazyUnmount {
+		args = append(args, "-z")
+	}
+	cmd := exec.Command(bin, args...)
 	cmd.Stderr = &errBuf
 	if opts.Debug {
 		log.Printf("unmount: executing %q", cmd.Args)


### PR DESCRIPTION
Refers to http://man.he.net/man1/fusermount

LazyMount allow go-fuse unmount works even if resource is still busy (opened by other user programs).