### PR TITLE
fusermount: Fix option escaping

### DIFF
--- a/fuse/test/mount_test.go
+++ b/fuse/test/mount_test.go
@@ -220,3 +220,19 @@ func TestLiveness(t *testing.T) {
 		t.Fatalf("ReadDir: %v", err)
 	}
 }
+
+// Test that fusermount doesn't exit when when using commas in options.
+func TestEscapedMountOption(t *testing.T) {
+	opts := &fuse.MountOptions{
+		FsName: "fsname,with,many,commas,",
+	}
+	mnt := t.TempDir()
+	fs := fuse.NewDefaultRawFileSystem()
+	srv, err := fuse.NewServer(fs, mnt, opts)
+	if err != nil {
+		t.Error(err)
+	} else {
+		go srv.Serve()
+		srv.Unmount()
+	}
+}


### PR DESCRIPTION
Hello @hanwen,

for the WCFS project [we need to escape commas in fusermount options](https://lab.nexedi.com/nexedi/wendelin.core/merge_requests/15):

> Before this patch no commas were allowed in any fusermount option string. But it is in fact possible to use commas in fusermount options: we only need to escape them [1].
>
> Now go-fuse users can use commas in fusermount options.
> 
> Related libfuse commits are [1] and [2].
>
> ---
>
> [1] https://github.com/libfuse/libfuse/commit/555d6b504308eac6b976321ce938ee4bec62c354
> [2] https://github.com/libfuse/libfuse/commit/5c094ac0150ebfef6a2c9c2c9d1c545a90ff4e96

In [sshfs commas were only escaped if FUSE_VERSION was >= 27](https://github.com/libfuse/sshfs/commit/be44229c), but [Kirill noted that the necessary changes are already very old and we could assume all nowadays used versions already support escaping](https://lab.nexedi.com/nexedi/wendelin.core/merge_requests/15#note_184090).

When running `bash all.bash` i couldn't see any failed tests, it seems all passed ok.

(I thought for a moment if it would make sense to remove user escaped commas before escaping commas in option strings, something like

```go
strings.Replace(strings.Replace(optionValue, "//,". ","), ",", "//,", -1)
```

to avoid constructs as `"////,"`, but I thought, it's too complicated).

Best, Levin