### PR TITLE
Fix panic when `/dev/null` does not exist

### DIFF
--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -40,7 +40,7 @@ func (p *Pair) WriteTo(fd uintptr, n int) (int, error) {
 const _SPLICE_F_NONBLOCK = 0x2
 
 func (p *Pair) discard() {
-	_, err := syscall.Splice(p.r, nil, int(devNullFD), nil, int(p.size), _SPLICE_F_NONBLOCK)
+	_, err := syscall.Splice(p.r, nil, devNullFD(), nil, int(p.size), _SPLICE_F_NONBLOCK)
 	if err == syscall.EAGAIN {
 		// all good.
 	} else if err != nil {


### PR DESCRIPTION
Fixes an issue that the `init()` func in splice.go panics if /dev is not yet mounted.

This allows supporting go-based init binaries which set up all the filesystems on the machine, including both /dev as well as FUSE-mounted dirs.
