### PR TITLE
feat: export `release_in` params

### DIFF
--- a/example/winfs/main.go
+++ b/example/winfs/main.go
@@ -75,10 +75,10 @@ func (n *WindowsNode) Create(ctx context.Context, name string, flags uint32, mod
 
 var _ = (fs.NodeReleaser)((*WindowsNode)(nil))
 
-func (n *WindowsNode) Release(ctx context.Context, f fs.FileHandle) syscall.Errno {
+func (n *WindowsNode) Release(ctx context.Context, f fs.FileHandle, in *fuse.ReleaseIn) syscall.Errno {
 	n.decrement()
 	if fr, ok := f.(fs.FileReleaser); ok {
-		return fr.Release(ctx)
+		return fr.Release(ctx, in)
 	}
 	return 0
 }

--- a/fs/api.go
+++ b/fs/api.go
@@ -381,7 +381,7 @@ type NodeFlusher interface {
 // could fail with I/O errors should happen in Flush instead.
 // The default implementation forwards to the FileHandle.
 type NodeReleaser interface {
-	Release(ctx context.Context, f FileHandle) syscall.Errno
+	Release(ctx context.Context, f FileHandle, in *fuse.ReleaseIn) syscall.Errno
 }
 
 // Allocate preallocates space for future writes, so they will
@@ -570,7 +570,7 @@ type FileHandle interface {
 
 // See NodeReleaser.
 type FileReleaser interface {
-	Release(ctx context.Context) syscall.Errno
+	Release(ctx context.Context, in *fuse.ReleaseIn) syscall.Errno
 }
 
 // See NodeGetattrer.

--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -824,9 +824,9 @@ func (b *rawBridge) Release(cancel <-chan struct{}, input *fuse.ReleaseIn) {
 
 	ctx := &fuse.Context{Caller: input.Caller, Cancel: cancel}
 	if r, ok := n.ops.(NodeReleaser); ok {
-		r.Release(ctx, f.file)
+		r.Release(ctx, f.file, input)
 	} else if r, ok := f.file.(FileReleaser); ok {
-		r.Release(ctx)
+		r.Release(ctx, input)
 	}
 
 	b.mu.Lock()

--- a/fs/files.go
+++ b/fs/files.go
@@ -58,7 +58,7 @@ func (f *loopbackFile) Write(ctx context.Context, data []byte, off int64) (uint3
 	return uint32(n), ToErrno(err)
 }
 
-func (f *loopbackFile) Release(ctx context.Context) syscall.Errno {
+func (f *loopbackFile) Release(ctx context.Context, in *fuse.ReleaseIn) syscall.Errno {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.fd != -1 {

--- a/fs/windows_example_test.go
+++ b/fs/windows_example_test.go
@@ -55,13 +55,13 @@ var _ = (fs.NodeReleaser)((*WindowsNode)(nil))
 // Release decreases the open count. The kernel doesn't wait with
 // returning from close(), so if the caller is too quick to
 // unlink/rename after calling close(), this may still trigger EBUSY.
-func (n *WindowsNode) Release(ctx context.Context, f fs.FileHandle) syscall.Errno {
+func (n *WindowsNode) Release(ctx context.Context, f fs.FileHandle, in *fuse.ReleaseIn) syscall.Errno {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	n.openCount--
 	if fr, ok := f.(fs.FileReleaser); ok {
-		return fr.Release(ctx)
+		return fr.Release(ctx, in)
 	}
 	return 0
 }


### PR DESCRIPTION
Sometimes we need to access the flags which first used by `Open` or other infomations that may match we needs.
Exporting `release_in` is the way to retrive the infomations.