### PR TITLE
Use `pipe` to reserve fd 3

### DIFF
--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -21,7 +21,7 @@ func init() {
 	for {
 		err := syscall.Pipe2(fdPair, syscall.O_CLOEXEC | syscall.O_NONBLOCK)
 		if err != nil {
-				panic(fmt.Sprintf("pipe2([]int{0, 0}, O_CLOEXEC | O_NONBLOCK): %v", err))
+			panic(fmt.Sprintf("pipe2([]int{0, 0}, O_CLOEXEC | O_NONBLOCK): %v", err))
 		}
 		if fdPair[0] > 3 || fdPair[1] > 3 {
 			for fd := range(fdPair) {


### PR DESCRIPTION
`/dev/null` is not always available when `go-fuse`'s `init` function runs, so instead of opening `/dev/null`, we make use of `socketpair` and `dup` to reserve file descriptor 3, as it is necessary to prevent deadlocks.
