### PR TITLE
fuse: replace deprecated StringBytePtr with BytePtrFromString

### DIFF
--- a/fuse/syscall_darwin.go
+++ b/fuse/syscall_darwin.go
@@ -11,8 +11,16 @@ import (
 )
 
 func getxattr(path string, attr string, dest []byte) (sz int, errno int) {
-	pathBs := syscall.StringBytePtr(path)
-	attrBs := syscall.StringBytePtr(attr)
+	pathBs, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return 0, int(syscall.EINVAL)
+	}
+
+	attrBs, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return 0, int(syscall.EINVAL)
+	}
+
 	size, _, errNo := syscall.Syscall6(
 		syscall.SYS_GETXATTR,
 		uintptr(unsafe.Pointer(pathBs)),
@@ -39,7 +47,11 @@ func GetXAttr(path string, attr string, dest []byte) (value []byte, errno int) {
 }
 
 func listxattr(path string, dest []byte) (sz int, errno int) {
-	pathbs := syscall.StringBytePtr(path)
+	pathbs, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return 0, int(syscall.EINVAL)
+	}
+
 	var destPointer unsafe.Pointer
 	if len(dest) > 0 {
 		destPointer = unsafe.Pointer(&dest[0])
@@ -76,8 +88,16 @@ func ListXAttr(path string) (attributes []string, errno int) {
 }
 
 func Setxattr(path string, attr string, data []byte, flags int) (errno int) {
-	pathbs := syscall.StringBytePtr(path)
-	attrbs := syscall.StringBytePtr(attr)
+	pathbs, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return int(syscall.EINVAL)
+	}
+
+	attrbs, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return int(syscall.EINVAL)
+	}
+
 	_, _, errNo := syscall.Syscall6(
 		syscall.SYS_SETXATTR,
 		uintptr(unsafe.Pointer(pathbs)),
@@ -90,8 +110,16 @@ func Setxattr(path string, attr string, data []byte, flags int) (errno int) {
 }
 
 func Removexattr(path string, attr string) (errno int) {
-	pathbs := syscall.StringBytePtr(path)
-	attrbs := syscall.StringBytePtr(attr)
+	pathbs, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return int(syscall.EINVAL)
+	}
+
+	attrbs, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return int(syscall.EINVAL)
+	}
+
 	_, _, errNo := syscall.Syscall(
 		syscall.SYS_REMOVEXATTR,
 		uintptr(unsafe.Pointer(pathbs)),


### PR DESCRIPTION
As mentioned in the Go codebase, the method `syscall.StringBytePtr` is deprecated and has to be replaced with `syscall.BytePtrFromString`.

```go
// StringBytePtr returns a pointer to a NUL-terminated array of bytes.
// If s contains a NUL byte this function panics instead of returning
// an error.
//
// Deprecated: Use [BytePtrFromString] instead.
func StringBytePtr(s string) *byte { return &StringByteSlice(s)[0] }

// BytePtrFromString returns a pointer to a NUL-terminated array of
// bytes containing the text of s. If s contains a NUL byte at any
// location, it returns (nil, [EINVAL]).
func BytePtrFromString(s string) (*byte, error) {
	a, err := ByteSliceFromString(s)
	if err != nil {
		return nil, err
	}
	return &a[0], nil
}
```
https://github.com/golang/go/blob/8a4b439ee6e0f5d41cb6ae30146b901f3c0ad4b7/src/syscall/syscall.go#L57-L73

This pull request replaces the deprecated method.

Change-Id: I31b52356438352829971c6b491d37fe09e088911