### PR TITLE
fuse: do not serialize headers until after adjustment

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -661,12 +661,14 @@ func (ms *Server) write(req *request) Status {
 			return OK
 		}
 	}
-	req.serializeHeader(req.outPayloadSize())
 
+	// Adjust header length for the INIT opcode on older versions, prior to
+	// serializing.
 	if req.inHeader().Opcode == _OP_INIT && ms.kernelSettings.Minor <= 22 {
 		// v8-v22 don't have TimeGran and further fields.
 		req.outHeader().Length = uint32(sizeOfOutHeader) + 24
 	}
+	req.serializeHeader(req.outPayloadSize())
 
 	if ms.opts.Debug {
 		ms.opts.Logger.Println(req.OutputDebug())


### PR DESCRIPTION
Older kernel versions do not support all the fields of the current INIT header. Adjust the header size before marshaling the header payload.

Updates #538