### PR TITLE
fuse: fix NewLoopbackDirStream on darwin

### DIFF
--- a/fs/dirstream.go
+++ b/fs/dirstream.go
@@ -29,6 +29,18 @@ func (a *dirArray) Close() {
 
 }
 
+func (a *dirArray) Releasedir(ctx context.Context, releaseFlags uint32) {
+	a.Close()
+}
+
+func (a *dirArray) Readdirent(ctx context.Context) (de *fuse.DirEntry, errno syscall.Errno) {
+	if !a.HasNext() {
+		return nil, 0
+	}
+	e, errno := a.Next()
+	return &e, errno
+}
+
 // NewListDirStream wraps a slice of DirEntry as a DirStream.
 func NewListDirStream(list []fuse.DirEntry) DirStream {
 	return &dirArray{list}


### PR DESCRIPTION
The rawBridge expects the returned FileHandle from OpendirHandle to be a FileReaddirenter. However, on Darwin, the NewLoopbackDirStream used in LoopbackNode.OpendirHandle returns a dirArray, which is not a FileReaddirenter. Consequently, the fs.NewLoopbackRoot function does not work on Darwin.

To address this issue, this commit implements FileReaddirenter/FileReleasedirer for dirArray.