### PR TITLE
Fix mount failure on legacy kernel 3.10

### DIFF
--- a/fuse/request.go
+++ b/fuse/request.go
@@ -270,6 +270,14 @@ func (r *request) serializeHeader(outPayloadSize int) {
 			dataLength = 0
 		}
 	}
+	// The InitOut structure has 24 bytes in fuse version <= 22.
+	// https://john-millikin.com/the-fuse-protocol#FUSE_INIT
+	if r.inHeader().Opcode == _OP_INIT {
+		out := (*InitOut)(r.outData())
+		if out.Minor <= 22 {
+			dataLength = 24
+		}
+	}
 
 	o := r.outHeader()
 	o.Unique = r.inHeader().Unique


### PR DESCRIPTION
`example/hello` fails to mount on my legacy Linux 3.10, with the following error message:

    writer: Write/Writev failed, err: 22=invalid argument. opcode: INIT
    Mount fail: init: 22=invalid argument

`strace` shows that the failure occurs when replying the INIT command.

    write(9,
          "P\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\7\0\0\0\26\0\0\0\0\20\0\0!0\0@"...,
          80) = -1 EINVAL (Invalid argument)

The length of InitOut (without common header) should be 24 in fuse protocol 7.22, rather than 64, according to [1].

This patch fixes the above issue.  It will response correct InitOut to kernel.

[1] https://john-millikin.com/the-fuse-protocol#FUSE_INIT