### PR TITLE
fs: Add a condition check for PassthroughFd to avoid invalid ioctl system calls

### DIFF
--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -782,7 +782,7 @@ func (b *rawBridge) addBackingID(n *Inode, f FileHandle, out *fuse.OpenOut) {
 
 	if n.backingID == 0 {
 		fd, ok := pth.PassthroughFd()
-		if !ok {
+		if !ok || fd <= 0 {
 			return
 		}
 		m := fuse.BackingMap{


### PR DESCRIPTION
Under normal conditions, the file descriptor may still be invalid. For example, in certain scenarios, users can control the return value of PassthroughFd to fine-tune whether passthrough mode should be enabled for a specific file. In such cases, it is possible to return immediately, thereby avoiding the overhead of an unnecessary ioctl system call.