### PR TITLE
fuse: add `EnableWritebackCaching` option to control writeback I/O mode

### DIFF
--- a/fuse/api.go
+++ b/fuse/api.go
@@ -332,6 +332,25 @@ type MountOptions struct {
 
 	// Disable splicing from files to the FUSE device.
 	DisableSplice bool
+
+    // If EnableWritebackCaching is enabled, writes go to the page cache only,
+    // which means that the write(2) syscall can often complete very fast
+    // when compared with FUSE's default write-through mode.
+    // If a partial page is written, then the page contents need to be first
+    // read from userspace. Thus, it is possible that READ requests generated
+    // by the kernel reach the FUSE server even for files opened as O_WRONLY.
+    //
+    // IMPORTANT:
+    // This mode can be useful to improve the throughput of small writes because
+    // fewer context switches and data copies need to be made between kernel
+    // and userspace. Do note, however, that this mode assumes that all changes
+    // to the filesystem go through the FUSE kernel module, so it's generally
+    // not suitable for network filesystems where strong consistency is a
+    // requirement.
+    //
+    // Refer to https://www.kernel.org/doc/Documentation/filesystems/fuse-io.txt
+    // for more information.
+	EnableWritebackCaching bool
 }
 
 // RawFileSystem is an interface close to the FUSE wire protocol.

--- a/fuse/opcode.go
+++ b/fuse/opcode.go
@@ -132,6 +132,10 @@ func doInit(server *protocolServer, req *request) {
 	}
 	kernelFlags |= dataCacheMode
 
+	if server.opts.EnableWritebackCaching {
+	    kernelFlags |= CAP_WRITEBACK_CACHE
+	}
+
 	// maxPages is the maximum request size we want the kernel to use, in units of
 	// memory pages (usually 4kiB). Linux v4.19 and older ignore this and always use
 	// 128kiB.


### PR DESCRIPTION
## Description

This PR adds a new `EnableWritebackCaching` option that allows users to set the `CAP_WRITEBACK_CACHE` when mounting the filesystem. This option changes the way in which write requests are processed reach the filesystem server: instead of each write being immediately sent to userspace as one or more WRITE requests, writes will be satisfied directly from the page cache. Since this option may have negative repercussions in networked filesystems, it is disabled by default.