### PR TITLE
fs: fix FMODE_EXEC in open

### DIFF
--- a/fs/loopback.go
+++ b/fs/loopback.go
@@ -359,6 +359,12 @@ var _ = (NodeOpener)((*LoopbackNode)(nil))
 // Symlink-safe through use of OpenSymlinkAware.
 func (n *LoopbackNode) Open(ctx context.Context, flags uint32) (fh FileHandle, fuseFlags uint32, errno syscall.Errno) {
 	flags = flags &^ syscall.O_APPEND
+	// Linux kernel transfers FMODE_EXEC (0x20) that is not defined in
+	// syscall package.
+	if flags & 0x20 != 0 {
+		flags = flags &^ 0x20
+		flags = flags | syscall.O_CLOEXEC
+	}
 
 	f, err := openat.OpenSymlinkAware(n.RootData.Path, n.relativePath(), int(flags), 0)
 	if err != nil {


### PR DESCRIPTION
There's an issue on running file. The steps are in below. 1) Mount a loopback directory. (mount point: /dev/shm/dst) 2) Create a script that could execute any shell command in the mounted directory.
3) Run the script directly.
$/dev/shm/dst/test.sh

Then it reports failure in below.
-bash: /dev/shm/dst/test.sh: /bin/sh: bad interpreter: Invalid argument

Linux kernel always transfers FMODE_EXEC flag to user space if it needs to open an executable file. But FMODE_EXEC flag isn't defined in syscall package. So transmute FMODE_EXEC flag into O_CLOEXEC flag instead. Otherwise, it causes open failure with invalid argument.