### PR TITLE
Allow to do the lookup for readdirplus without going through the parent node

### DIFF
--- a/fs/api.go
+++ b/fs/api.go
@@ -703,10 +703,26 @@ type NodeOpendirHandler interface {
 	OpendirHandle(ctx context.Context, flags uint32) (fh FileHandle, fuseFlags uint32, errno syscall.Errno)
 }
 
+type HasDirEntry interface {
+	GetDirEntry(out *fuse.DirEntry)
+}
+
+type DirEntryLookuper interface {
+	Lookup(ctx context.Context, parent *Inode, out *fuse.EntryOut) (*Inode, syscall.Errno)
+}
+
+type SimpleDirEntry struct {
+	DirEntry *fuse.DirEntry
+}
+
+func (sde SimpleDirEntry) GetDirEntry(out *fuse.DirEntry) {
+	*out = *sde.DirEntry
+}
+
 // FileReaddirenter is a directory that supports reading.
 type FileReaddirenter interface {
 	// Read a single directory entry.
-	Readdirent(ctx context.Context) (*fuse.DirEntry, syscall.Errno)
+	Readdirent(ctx context.Context) (HasDirEntry, syscall.Errno)
 }
 
 // FileFsyncer is a directory that supports fsyncdir.

--- a/fs/dir_test.go
+++ b/fs/dir_test.go
@@ -115,13 +115,13 @@ type listDirEntries struct {
 
 var _ = (FileReaddirenter)((*listDirEntries)(nil))
 
-func (l *listDirEntries) Readdirent(ctx context.Context) (*fuse.DirEntry, syscall.Errno) {
+func (l *listDirEntries) Readdirent(ctx context.Context) (HasDirEntry, syscall.Errno) {
 	if l.next >= len(l.entries) {
 		return nil, 0
 	}
 	de := &l.entries[l.next]
 	l.next++
-	return de, 0
+	return SimpleDirEntry{de}, 0
 }
 
 var _ = (FileSeekdirer)((*listDirEntries)(nil))
@@ -223,7 +223,7 @@ type syncDir struct {
 	node *syncNode
 }
 
-func (d *syncDir) Readdirent(ctx context.Context) (*fuse.DirEntry, syscall.Errno) {
+func (d *syncDir) Readdirent(ctx context.Context) (HasDirEntry, syscall.Errno) {
 	return nil, 0
 }
 

--- a/fs/dircache_test.go
+++ b/fs/dircache_test.go
@@ -29,7 +29,7 @@ type countingReaddirenter struct {
 	*dirCacheTestNode
 }
 
-func (r *countingReaddirenter) Readdirent(ctx context.Context) (*fuse.DirEntry, syscall.Errno) {
+func (r *countingReaddirenter) Readdirent(ctx context.Context) (HasDirEntry, syscall.Errno) {
 	de, errno := r.FileReaddirenter.Readdirent(ctx)
 	r.dirCacheTestNode.mu.Lock()
 	defer r.dirCacheTestNode.mu.Unlock()

--- a/fs/dirstream.go
+++ b/fs/dirstream.go
@@ -44,12 +44,12 @@ func (a *dirArray) Close() {
 
 func (a *dirArray) Releasedir(ctx context.Context, releaseFlags uint32) {}
 
-func (a *dirArray) Readdirent(ctx context.Context) (de *fuse.DirEntry, errno syscall.Errno) {
+func (a *dirArray) Readdirent(ctx context.Context) (de HasDirEntry, errno syscall.Errno) {
 	if !a.HasNext() {
 		return nil, 0
 	}
 	e, errno := a.Next()
-	return &e, errno
+	return SimpleDirEntry{&e}, errno
 }
 
 // NewLoopbackDirStream opens a directory for reading as a DirStream
@@ -79,7 +79,7 @@ func (d *dirStreamAsFile) Releasedir(ctx context.Context, releaseFlags uint32) {
 	}
 }
 
-func (d *dirStreamAsFile) Readdirent(ctx context.Context) (de *fuse.DirEntry, errno syscall.Errno) {
+func (d *dirStreamAsFile) Readdirent(ctx context.Context) (de HasDirEntry, errno syscall.Errno) {
 	if d.ds == nil {
 		d.ds, errno = d.creator(ctx)
 		if errno != 0 {
@@ -91,7 +91,7 @@ func (d *dirStreamAsFile) Readdirent(ctx context.Context) (de *fuse.DirEntry, er
 	}
 
 	e, errno := d.ds.Next()
-	return &e, errno
+	return SimpleDirEntry{&e}, errno
 }
 
 func (d *dirStreamAsFile) Seekdir(ctx context.Context, off uint64) syscall.Errno {
@@ -178,12 +178,12 @@ func (ds *loopbackDirStream) HasNext() bool {
 
 var _ = (FileReaddirenter)((*loopbackDirStream)(nil))
 
-func (ds *loopbackDirStream) Readdirent(ctx context.Context) (*fuse.DirEntry, syscall.Errno) {
+func (ds *loopbackDirStream) Readdirent(ctx context.Context) (HasDirEntry, syscall.Errno) {
 	if !ds.HasNext() {
 		return nil, 0
 	}
 	de, errno := ds.Next()
-	return &de, errno
+	return SimpleDirEntry{&de}, errno
 }
 
 func (ds *loopbackDirStream) Next() (fuse.DirEntry, syscall.Errno) {


### PR DESCRIPTION
In cases where the readdir object already contains the result of the stat, this allows for a much less awkward implementation.