### PR TITLE
.github: add go 1.25 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - "1.22.x" # Golang upstream stable
           - "1.23.x" # Golang upstream stable
           - "1.24.x" # Golang upstream stable
+          - "1.25.x" # Golang upstream stable
         GOMAXPROCS:
           - ""  # Use all cpus (default).
           - "1" # Single-cpu mode. Some failures are only visible like this.


### PR DESCRIPTION
Resolve https://github.com/hanwen/go-fuse/issues/587