### PR TITLE
fs: NewNodeFS: actually handle opts = nil

### DIFF
--- a/example/loopback/main.go
+++ b/example/loopback/main.go
@@ -16,7 +16,6 @@ import (
 	"path"
 	"runtime/pprof"
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -92,24 +91,16 @@ func main() {
 		log.Fatalf("NewLoopbackRoot(%s): %v\n", orig, err)
 	}
 
-	sec := time.Second
-	opts := &fs.Options{
-		// The timeout options are to be compatible with libfuse defaults,
-		// making benchmarking easier.
-		AttrTimeout:  &sec,
-		EntryTimeout: &sec,
-
-		NullPermissions: true, // Leave file permissions on "000" files as-is
-
-		MountOptions: fuse.MountOptions{
-			AllowOther:        *other,
-			Debug:             *debug,
-			DirectMount:       *directmount,
-			DirectMountStrict: *directmountstrict,
-			IDMappedMount:     *idmap,
-			FsName:            orig,       // First column in "df -T": original dir
-			Name:              "loopback", // Second column in "df -T" will be shown as "fuse." + Name
-		},
+	opts := fs.DefaultOptions()
+	opts.NullPermissions = true // Leave file permissions on "000" files as-is
+	opts.MountOptions = fuse.MountOptions{
+		AllowOther:        *other,
+		Debug:             *debug,
+		DirectMount:       *directmount,
+		DirectMountStrict: *directmountstrict,
+		IDMappedMount:     *idmap,
+		FsName:            orig,       // First column in "df -T": original dir
+		Name:              "loopback", // Second column in "df -T" will be shown as "fuse." + Name
 	}
 	if opts.AllowOther {
 		// Make the kernel check file permissions for us

--- a/example/multizip/main.go
+++ b/example/multizip/main.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/zipfs"
@@ -30,13 +29,9 @@ func main() {
 	}
 
 	root := &zipfs.MultiZipFs{}
-	sec := time.Second
-	opts := fs.Options{
-		EntryTimeout: &sec,
-		AttrTimeout:  &sec,
-	}
+	opts := fs.DefaultOptions()
 	opts.Debug = *debug
-	server, err := fs.Mount(flag.Arg(0), root, &opts)
+	server, err := fs.Mount(flag.Arg(0), root, opts)
 	if err != nil {
 		fmt.Printf("Mount fail: %v\n", err)
 		os.Exit(1)

--- a/example/winfs/main.go
+++ b/example/winfs/main.go
@@ -142,11 +142,7 @@ func main() {
 		Path:    orig,
 	}
 
-	sec := time.Second
-	opts := &fs.Options{
-		AttrTimeout:  &sec,
-		EntryTimeout: &sec,
-	}
+	opts := fs.DefaultOptions()
 	opts.Debug = *debug
 	opts.MountOptions.Options = append(opts.MountOptions.Options, "fsname="+orig)
 	opts.MountOptions.Name = "winfs"

--- a/fs/bridge.go
+++ b/fs/bridge.go
@@ -10,7 +10,6 @@ import (
 	"runtime/debug"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/hanwen/go-fuse/v2/internal"
@@ -290,11 +289,7 @@ func (b *rawBridge) setAttrTimeout(out *fuse.AttrOut) {
 // applied, which are 1 second entry and attribute timeout.
 func NewNodeFS(root InodeEmbedder, opts *Options) fuse.RawFileSystem {
 	if opts == nil {
-		oneSec := time.Second
-		opts = &Options{
-			EntryTimeout: &oneSec,
-			AttrTimeout:  &oneSec,
-		}
+		opts = DefaultOptions()
 	}
 	bridge := &rawBridge{
 		automaticIno: opts.FirstAutomaticIno,
@@ -305,7 +300,7 @@ func NewNodeFS(root InodeEmbedder, opts *Options) fuse.RawFileSystem {
 	}
 
 	if bridge.automaticIno == 0 {
-		bridge.automaticIno = 1 << 63
+		bridge.automaticIno = DefaultOptions().FirstAutomaticIno
 	}
 
 	stableAttr := StableAttr{

--- a/fs/default.go
+++ b/fs/default.go
@@ -3,3 +3,22 @@
 // license that can be found in the LICENSE file.
 
 package fs
+
+import (
+	"time"
+)
+
+// DefaultOptions returns the default Options that are used when
+// nil is passed for *Options.
+//
+// When you do want to set something in Options, get the defaults
+// from this function and adjust as required.
+func DefaultOptions() *Options {
+	oneSec := time.Second
+	return &Options{
+		// libfuse also uses one second per default
+		EntryTimeout:      &oneSec,
+		AttrTimeout:       &oneSec,
+		FirstAutomaticIno: 1 << 63,
+	}
+}

--- a/fs/dir_test.go
+++ b/fs/dir_test.go
@@ -244,8 +244,7 @@ func (n *syncNode) OpendirHandle(ctx context.Context, flags uint32) (FileHandle,
 
 func TestFsyncDir(t *testing.T) {
 	root := &syncNode{}
-	opts := Options{}
-	mnt, _ := testMount(t, root, &opts)
+	mnt, _ := testMount(t, root, nil)
 
 	fd, err := syscall.Open(mnt, syscall.O_DIRECTORY, 0)
 	if err != nil {

--- a/fs/interrupt_test.go
+++ b/fs/interrupt_test.go
@@ -54,11 +54,7 @@ func (o *interruptOps) Open(ctx context.Context, flags uint32) (FileHandle, uint
 func TestInterrupt(t *testing.T) {
 	root := &interruptRoot{}
 
-	oneSec := time.Second
-	mntDir, server := testMount(t, root, &Options{
-		EntryTimeout: &oneSec,
-		AttrTimeout:  &oneSec,
-	})
+	mntDir, server := testMount(t, root, DefaultOptions())
 
 	cmd := exec.Command("cat", mntDir+"/file")
 	if err := cmd.Start(); err != nil {

--- a/fs/loopback_linux_test.go
+++ b/fs/loopback_linux_test.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"syscall"
 	"testing"
-	"time"
 	"unsafe"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -287,11 +286,7 @@ func TestParallelDiropsHang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLoopbackRoot(%s): %v\n", orig, err)
 	}
-	sec := time.Second
-	opts := &Options{
-		AttrTimeout:  &sec,
-		EntryTimeout: &sec,
-	}
+	opts := DefaultOptions()
 	opts.Debug = testutil.VerboseTest()
 
 	rawFS := NewNodeFS(loopbackRoot, opts)

--- a/fs/windows_example_test.go
+++ b/fs/windows_example_test.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -107,11 +106,7 @@ func Example_loopbackReuse() {
 		Path: origDir,
 	}
 
-	sec := time.Second
-	opts := &fs.Options{
-		AttrTimeout:  &sec,
-		EntryTimeout: &sec,
-	}
+	opts := fs.DefaultOptions()
 
 	root := &WindowsNode{
 		LoopbackNode: &fs.LoopbackNode{


### PR DESCRIPTION
Cross-post of https://review.gerrithub.io/c/hanwen/go-fuse/+/1228929 for CI


-----------------


Parts of the function did handle opts = nil, other parts did not.

Handle it right at entry like fuse.NewServer,
and document it.

Change-Id: I265f1d7cb96a926879ca6769a0d08e613795b9cd