### PR TITLE
fuse: pass through parent environment in callFusermount

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -26,6 +26,18 @@ func unixgramSocketpair() (l, r *os.File, err error) {
 	return
 }
 
+// filterEnv returns a copy of env with any entries starting with key+"=" removed.
+func filterEnv(env []string, key string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
 // Create a FUSE FS on the specified mount point without using
 // fusermount.
 func mountDirect(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, err error) {
@@ -142,7 +154,7 @@ func callFusermount(mountPoint string, opts *MountOptions) (fd int, err error) {
 	proc, err := os.StartProcess(bin,
 		cmd,
 		&os.ProcAttr{
-			Env:   []string{"_FUSE_COMMFD=3"},
+			Env:   append(filterEnv(os.Environ(), "_FUSE_COMMFD"), "_FUSE_COMMFD=3"),
 			Files: []*os.File{os.Stdin, os.Stdout, os.Stderr, remote}})
 
 	if err != nil {

--- a/fuse/mount_linux_test.go
+++ b/fuse/mount_linux_test.go
@@ -234,6 +234,32 @@ fusermount:        %#v`, o3, o1)
 	}
 }
 
+func TestFilterEnv(t *testing.T) {
+	env := []string{"FOO=bar", "_FUSE_COMMFD=99", "PATH=/usr/bin", "_FUSE_COMMFD=other"}
+	got := filterEnv(env, "_FUSE_COMMFD")
+	want := []string{"FOO=bar", "PATH=/usr/bin"}
+	if len(got) != len(want) {
+		t.Fatalf("filterEnv: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("filterEnv[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// Key not present — should return all entries.
+	got2 := filterEnv(env, "NOTEXIST")
+	if len(got2) != len(env) {
+		t.Fatalf("filterEnv(NOTEXIST): got %d entries, want %d", len(got2), len(env))
+	}
+
+	// Empty env.
+	got3 := filterEnv(nil, "_FUSE_COMMFD")
+	if len(got3) != 0 {
+		t.Fatalf("filterEnv(nil): got %v, want empty", got3)
+	}
+}
+
 // TestEscapedMountOption tests that fusermount doesn't exit when when using commas or backslashs in options.
 // It also tests that commas or backslashs in options are correctly propagated to /proc/mounts.
 func TestEscapedMountOption(t *testing.T) {


### PR DESCRIPTION
## Problem

`callFusermount()` in `mount_linux.go` passes only `_FUSE_COMMFD=3` as the environment to the fusermount subprocess, stripping all other environment variables from the parent process:

```go
Env: []string{"_FUSE_COMMFD=3"},
```

This breaks any fusermount replacement that needs additional environment variables — most notably [meta-fuse-csi-plugin](https://github.com/pfnet-research/meta-fuse-csi-plugin)'s `fusermount3-proxy`, which requires `FUSERMOUNT3PROXY_FDPASSING_SOCKPATH` to locate the CSI driver's fd-passing socket.

## Root Cause

go-fuse is not the security boundary here. It is up to the fusermount binary itself to protect against environment variables if necessary. Stripping the environment at the go-fuse level is unnecessary and actively harmful to fusermount3 wrappers/replacements that rely on environment variables for configuration.

## Fix

Pass through the parent process's full environment, ensuring `_FUSE_COMMFD=3` is included (overriding any existing value):

```go
Env: append(filterEnv(os.Environ(), "_FUSE_COMMFD"), "_FUSE_COMMFD=3"),
```

The new `filterEnv()` helper removes any pre-existing `_FUSE_COMMFD` entries to prevent conflicts before appending the correct value.

## Notes

- **Security**: `_FUSE_COMMFD` is still explicitly set to `3`, overriding any inherited value, so the fd-passing mechanism remains correct.
- **Consistency**: `unmount()` in the same file already inherits the full environment via `exec.Command`, so this makes `callFusermount()` consistent.
- **Testing**: Added `TestFilterEnv` to verify the helper function handles key filtering, missing keys, and empty environments correctly.